### PR TITLE
Add function for getting endpoints, sorted by response time

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,9 @@
+export const prop = (key: string) => (context: any) => context[key];
+
+export const sortBy = (evalFn: (arg0: any) => any) => (xs: any[]) => xs.sort((a, b) => evalFn(a) - evalFn(b));
+
+export const map = (fn: any) => (xs: any[]) => xs.map(fn);
+
+export const filter = (fn: any) => (xs: any[]) => xs.filter(fn);
+
+export const awaitAll = Promise.all.bind(Promise);


### PR DESCRIPTION
Adds new function 'getEndpointsSorted` to the network module. This will return a list of endpoints, but filter out any that are unresponsive and sort the responsive ones by response time.