### PR TITLE
Use ts-proto to create type registry

### DIFF
--- a/script/generate.sh
+++ b/script/generate.sh
@@ -17,7 +17,7 @@ if protoc \
     --plugin="./node_modules/.bin/protoc-gen-ts_proto" \
     --proto_path=${PROTO_PATH} \
     --ts_proto_out=${OUTPUT_DIR} \
-    --ts_proto_opt=esModuleInterop=true,forceLong=long,useOptionals=messages \
+    --ts_proto_opt=esModuleInterop=true,forceLong=long,useOptionals=messages,outputTypeRegistry=true \
     ${SRC_PATHS}; then
     echo "ok";
 else

--- a/src/certificates/index.ts
+++ b/src/certificates/index.ts
@@ -29,6 +29,7 @@ export async function broadcastCertificate(
     cert: encodedCsr,
     pubkey: encdodedPublicKey,
   });
+
   return await client.signAndBroadcast(owner, [message.message], message.fee);
 }
 

--- a/src/keplr/index.ts
+++ b/src/keplr/index.ts
@@ -1,4 +1,4 @@
-import { registry } from "../stargate";
+import { getAkashTypeRegistry } from "../stargate";
 import { defaultRegistryTypes, SigningStargateClient } from "@cosmjs/stargate";
 import { Registry } from "@cosmjs/proto-signing";
 
@@ -16,7 +16,7 @@ export function getSigner(chain: any) {
 export async function get(chain: any, signer: any) {
   const myRegistry = new Registry([
     ...defaultRegistryTypes,
-    ...(registry as any),
+    ...getAkashTypeRegistry(),
   ]);
   return await SigningStargateClient.connectWithSigner(
     `https://bridge.testnet.akash.network/akashnetwork`,

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -52,14 +52,13 @@ interface INetworkMetadata {
 
 // TODO: this should probably be cached to avoid pulling for every request
 export async function getMetadata(network: NETWORK_TYPE): Promise<INetworkMetadata> {
-    const url = `https://raw.githubusercontent.com/ovrclk/net/master/${network}/meta.json`;
-    const res = await fetch(url);
-
-    return res.json();
+    return fetch(`https://raw.githubusercontent.com/ovrclk/net/master/${network}/meta.json`)
+        .then(res => res.json());
 }
 
 export function getEndpoints(network: NETWORK_TYPE, type: ENDPOINT_TYPE) {
-    return getMetadata(network).then(meta => meta.apis[type]);
+    return getMetadata(network)
+        .then(meta => meta.apis[type]);
 }
 
 export function getEndpointsSorted(network: NETWORK_TYPE, type: ENDPOINT_TYPE) {

--- a/src/protobuf/akash/audit/v1beta1/audit.ts
+++ b/src/protobuf/akash/audit/v1beta1/audit.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Attribute } from "../../../akash/base/v1beta1/attribute";
@@ -7,6 +8,7 @@ export const protobufPackage = "akash.audit.v1beta1";
 
 /** Provider stores owner auditor and attributes details */
 export interface Provider {
+  $type: "akash.audit.v1beta1.Provider";
   owner: string;
   auditor: string;
   attributes: Attribute[];
@@ -14,6 +16,7 @@ export interface Provider {
 
 /** Attributes */
 export interface AuditedAttributes {
+  $type: "akash.audit.v1beta1.AuditedAttributes";
   owner: string;
   auditor: string;
   attributes: Attribute[];
@@ -21,40 +24,55 @@ export interface AuditedAttributes {
 
 /** AttributesResponse represents details of deployment along with group details */
 export interface AttributesResponse {
+  $type: "akash.audit.v1beta1.AttributesResponse";
   attributes: AuditedAttributes[];
 }
 
 /** AttributesFilters defines filters used to filter deployments */
 export interface AttributesFilters {
+  $type: "akash.audit.v1beta1.AttributesFilters";
   auditors: string[];
   owners: string[];
 }
 
 /** MsgSignProviderAttributes defines an SDK message for signing a provider attributes */
 export interface MsgSignProviderAttributes {
+  $type: "akash.audit.v1beta1.MsgSignProviderAttributes";
   owner: string;
   auditor: string;
   attributes: Attribute[];
 }
 
 /** MsgSignProviderAttributesResponse defines the Msg/CreateProvider response type. */
-export interface MsgSignProviderAttributesResponse {}
+export interface MsgSignProviderAttributesResponse {
+  $type: "akash.audit.v1beta1.MsgSignProviderAttributesResponse";
+}
 
 /** MsgDeleteProviderAttributes defined the Msg/DeleteProviderAttributes */
 export interface MsgDeleteProviderAttributes {
+  $type: "akash.audit.v1beta1.MsgDeleteProviderAttributes";
   owner: string;
   auditor: string;
   keys: string[];
 }
 
 /** MsgDeleteProviderAttributesResponse defines the Msg/ProviderAttributes response type. */
-export interface MsgDeleteProviderAttributesResponse {}
+export interface MsgDeleteProviderAttributesResponse {
+  $type: "akash.audit.v1beta1.MsgDeleteProviderAttributesResponse";
+}
 
 function createBaseProvider(): Provider {
-  return { owner: "", auditor: "", attributes: [] };
+  return {
+    $type: "akash.audit.v1beta1.Provider",
+    owner: "",
+    auditor: "",
+    attributes: [],
+  };
 }
 
 export const Provider = {
+  $type: "akash.audit.v1beta1.Provider" as const,
+
   encode(
     message: Provider,
     writer: _m0.Writer = _m0.Writer.create()
@@ -97,6 +115,7 @@ export const Provider = {
 
   fromJSON(object: any): Provider {
     return {
+      $type: Provider.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       attributes: Array.isArray(object?.attributes)
@@ -129,11 +148,20 @@ export const Provider = {
   },
 };
 
+messageTypeRegistry.set(Provider.$type, Provider);
+
 function createBaseAuditedAttributes(): AuditedAttributes {
-  return { owner: "", auditor: "", attributes: [] };
+  return {
+    $type: "akash.audit.v1beta1.AuditedAttributes",
+    owner: "",
+    auditor: "",
+    attributes: [],
+  };
 }
 
 export const AuditedAttributes = {
+  $type: "akash.audit.v1beta1.AuditedAttributes" as const,
+
   encode(
     message: AuditedAttributes,
     writer: _m0.Writer = _m0.Writer.create()
@@ -176,6 +204,7 @@ export const AuditedAttributes = {
 
   fromJSON(object: any): AuditedAttributes {
     return {
+      $type: AuditedAttributes.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       attributes: Array.isArray(object?.attributes)
@@ -210,11 +239,15 @@ export const AuditedAttributes = {
   },
 };
 
+messageTypeRegistry.set(AuditedAttributes.$type, AuditedAttributes);
+
 function createBaseAttributesResponse(): AttributesResponse {
-  return { attributes: [] };
+  return { $type: "akash.audit.v1beta1.AttributesResponse", attributes: [] };
 }
 
 export const AttributesResponse = {
+  $type: "akash.audit.v1beta1.AttributesResponse" as const,
+
   encode(
     message: AttributesResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -247,6 +280,7 @@ export const AttributesResponse = {
 
   fromJSON(object: any): AttributesResponse {
     return {
+      $type: AttributesResponse.$type,
       attributes: Array.isArray(object?.attributes)
         ? object.attributes.map((e: any) => AuditedAttributes.fromJSON(e))
         : [],
@@ -275,11 +309,19 @@ export const AttributesResponse = {
   },
 };
 
+messageTypeRegistry.set(AttributesResponse.$type, AttributesResponse);
+
 function createBaseAttributesFilters(): AttributesFilters {
-  return { auditors: [], owners: [] };
+  return {
+    $type: "akash.audit.v1beta1.AttributesFilters",
+    auditors: [],
+    owners: [],
+  };
 }
 
 export const AttributesFilters = {
+  $type: "akash.audit.v1beta1.AttributesFilters" as const,
+
   encode(
     message: AttributesFilters,
     writer: _m0.Writer = _m0.Writer.create()
@@ -316,6 +358,7 @@ export const AttributesFilters = {
 
   fromJSON(object: any): AttributesFilters {
     return {
+      $type: AttributesFilters.$type,
       auditors: Array.isArray(object?.auditors)
         ? object.auditors.map((e: any) => String(e))
         : [],
@@ -350,11 +393,20 @@ export const AttributesFilters = {
   },
 };
 
+messageTypeRegistry.set(AttributesFilters.$type, AttributesFilters);
+
 function createBaseMsgSignProviderAttributes(): MsgSignProviderAttributes {
-  return { owner: "", auditor: "", attributes: [] };
+  return {
+    $type: "akash.audit.v1beta1.MsgSignProviderAttributes",
+    owner: "",
+    auditor: "",
+    attributes: [],
+  };
 }
 
 export const MsgSignProviderAttributes = {
+  $type: "akash.audit.v1beta1.MsgSignProviderAttributes" as const,
+
   encode(
     message: MsgSignProviderAttributes,
     writer: _m0.Writer = _m0.Writer.create()
@@ -400,6 +452,7 @@ export const MsgSignProviderAttributes = {
 
   fromJSON(object: any): MsgSignProviderAttributes {
     return {
+      $type: MsgSignProviderAttributes.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       attributes: Array.isArray(object?.attributes)
@@ -434,11 +487,18 @@ export const MsgSignProviderAttributes = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgSignProviderAttributes.$type,
+  MsgSignProviderAttributes
+);
+
 function createBaseMsgSignProviderAttributesResponse(): MsgSignProviderAttributesResponse {
-  return {};
+  return { $type: "akash.audit.v1beta1.MsgSignProviderAttributesResponse" };
 }
 
 export const MsgSignProviderAttributesResponse = {
+  $type: "akash.audit.v1beta1.MsgSignProviderAttributesResponse" as const,
+
   encode(
     _: MsgSignProviderAttributesResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -465,7 +525,9 @@ export const MsgSignProviderAttributesResponse = {
   },
 
   fromJSON(_: any): MsgSignProviderAttributesResponse {
-    return {};
+    return {
+      $type: MsgSignProviderAttributesResponse.$type,
+    };
   },
 
   toJSON(_: MsgSignProviderAttributesResponse): unknown {
@@ -481,11 +543,23 @@ export const MsgSignProviderAttributesResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgSignProviderAttributesResponse.$type,
+  MsgSignProviderAttributesResponse
+);
+
 function createBaseMsgDeleteProviderAttributes(): MsgDeleteProviderAttributes {
-  return { owner: "", auditor: "", keys: [] };
+  return {
+    $type: "akash.audit.v1beta1.MsgDeleteProviderAttributes",
+    owner: "",
+    auditor: "",
+    keys: [],
+  };
 }
 
 export const MsgDeleteProviderAttributes = {
+  $type: "akash.audit.v1beta1.MsgDeleteProviderAttributes" as const,
+
   encode(
     message: MsgDeleteProviderAttributes,
     writer: _m0.Writer = _m0.Writer.create()
@@ -531,6 +605,7 @@ export const MsgDeleteProviderAttributes = {
 
   fromJSON(object: any): MsgDeleteProviderAttributes {
     return {
+      $type: MsgDeleteProviderAttributes.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       keys: Array.isArray(object?.keys)
@@ -562,11 +637,18 @@ export const MsgDeleteProviderAttributes = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgDeleteProviderAttributes.$type,
+  MsgDeleteProviderAttributes
+);
+
 function createBaseMsgDeleteProviderAttributesResponse(): MsgDeleteProviderAttributesResponse {
-  return {};
+  return { $type: "akash.audit.v1beta1.MsgDeleteProviderAttributesResponse" };
 }
 
 export const MsgDeleteProviderAttributesResponse = {
+  $type: "akash.audit.v1beta1.MsgDeleteProviderAttributesResponse" as const,
+
   encode(
     _: MsgDeleteProviderAttributesResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -593,7 +675,9 @@ export const MsgDeleteProviderAttributesResponse = {
   },
 
   fromJSON(_: any): MsgDeleteProviderAttributesResponse {
-    return {};
+    return {
+      $type: MsgDeleteProviderAttributesResponse.$type,
+    };
   },
 
   toJSON(_: MsgDeleteProviderAttributesResponse): unknown {
@@ -608,6 +692,11 @@ export const MsgDeleteProviderAttributesResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(
+  MsgDeleteProviderAttributesResponse.$type,
+  MsgDeleteProviderAttributesResponse
+);
 
 /** Msg defines the provider Msg service */
 export interface Msg {
@@ -683,14 +772,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/audit/v1beta1/genesis.ts
+++ b/src/protobuf/akash/audit/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { AuditedAttributes } from "../../../akash/audit/v1beta1/audit";
@@ -7,14 +8,17 @@ export const protobufPackage = "akash.audit.v1beta1";
 
 /** GenesisState defines the basic genesis state used by audit module */
 export interface GenesisState {
+  $type: "akash.audit.v1beta1.GenesisState";
   attributes: AuditedAttributes[];
 }
 
 function createBaseGenesisState(): GenesisState {
-  return { attributes: [] };
+  return { $type: "akash.audit.v1beta1.GenesisState", attributes: [] };
 }
 
 export const GenesisState = {
+  $type: "akash.audit.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -47,6 +51,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       attributes: Array.isArray(object?.attributes)
         ? object.attributes.map((e: any) => AuditedAttributes.fromJSON(e))
         : [],
@@ -75,6 +80,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -93,14 +100,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/audit/v1beta1/query.ts
+++ b/src/protobuf/akash/audit/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -11,44 +12,56 @@ export const protobufPackage = "akash.audit.v1beta1";
 
 /** QueryProvidersResponse is response type for the Query/Providers RPC method */
 export interface QueryProvidersResponse {
+  $type: "akash.audit.v1beta1.QueryProvidersResponse";
   providers: Provider[];
   pagination?: PageResponse;
 }
 
 /** QueryProviderRequest is request type for the Query/Provider RPC method */
 export interface QueryProviderRequest {
+  $type: "akash.audit.v1beta1.QueryProviderRequest";
   auditor: string;
   owner: string;
 }
 
 /** QueryAllProvidersAttributesRequest is request type for the Query/All Providers RPC method */
 export interface QueryAllProvidersAttributesRequest {
+  $type: "akash.audit.v1beta1.QueryAllProvidersAttributesRequest";
   pagination?: PageRequest;
 }
 
 /** QueryProviderAttributesRequest is request type for the Query/Provider RPC method */
 export interface QueryProviderAttributesRequest {
+  $type: "akash.audit.v1beta1.QueryProviderAttributesRequest";
   owner: string;
   pagination?: PageRequest;
 }
 
 /** QueryProviderAuditorRequest is request type for the Query/Providers RPC method */
 export interface QueryProviderAuditorRequest {
+  $type: "akash.audit.v1beta1.QueryProviderAuditorRequest";
   auditor: string;
   owner: string;
 }
 
 /** QueryAuditorAttributesRequest is request type for the Query/Providers RPC method */
 export interface QueryAuditorAttributesRequest {
+  $type: "akash.audit.v1beta1.QueryAuditorAttributesRequest";
   auditor: string;
   pagination?: PageRequest;
 }
 
 function createBaseQueryProvidersResponse(): QueryProvidersResponse {
-  return { providers: [], pagination: undefined };
+  return {
+    $type: "akash.audit.v1beta1.QueryProvidersResponse",
+    providers: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryProvidersResponse = {
+  $type: "akash.audit.v1beta1.QueryProvidersResponse" as const,
+
   encode(
     message: QueryProvidersResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -91,6 +104,7 @@ export const QueryProvidersResponse = {
 
   fromJSON(object: any): QueryProvidersResponse {
     return {
+      $type: QueryProvidersResponse.$type,
       providers: Array.isArray(object?.providers)
         ? object.providers.map((e: any) => Provider.fromJSON(e))
         : [],
@@ -130,11 +144,19 @@ export const QueryProvidersResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryProvidersResponse.$type, QueryProvidersResponse);
+
 function createBaseQueryProviderRequest(): QueryProviderRequest {
-  return { auditor: "", owner: "" };
+  return {
+    $type: "akash.audit.v1beta1.QueryProviderRequest",
+    auditor: "",
+    owner: "",
+  };
 }
 
 export const QueryProviderRequest = {
+  $type: "akash.audit.v1beta1.QueryProviderRequest" as const,
+
   encode(
     message: QueryProviderRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -174,6 +196,7 @@ export const QueryProviderRequest = {
 
   fromJSON(object: any): QueryProviderRequest {
     return {
+      $type: QueryProviderRequest.$type,
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       owner: isSet(object.owner) ? String(object.owner) : "",
     };
@@ -196,11 +219,18 @@ export const QueryProviderRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryProviderRequest.$type, QueryProviderRequest);
+
 function createBaseQueryAllProvidersAttributesRequest(): QueryAllProvidersAttributesRequest {
-  return { pagination: undefined };
+  return {
+    $type: "akash.audit.v1beta1.QueryAllProvidersAttributesRequest",
+    pagination: undefined,
+  };
 }
 
 export const QueryAllProvidersAttributesRequest = {
+  $type: "akash.audit.v1beta1.QueryAllProvidersAttributesRequest" as const,
+
   encode(
     message: QueryAllProvidersAttributesRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -234,6 +264,7 @@ export const QueryAllProvidersAttributesRequest = {
 
   fromJSON(object: any): QueryAllProvidersAttributesRequest {
     return {
+      $type: QueryAllProvidersAttributesRequest.$type,
       pagination: isSet(object.pagination)
         ? PageRequest.fromJSON(object.pagination)
         : undefined,
@@ -261,11 +292,22 @@ export const QueryAllProvidersAttributesRequest = {
   },
 };
 
+messageTypeRegistry.set(
+  QueryAllProvidersAttributesRequest.$type,
+  QueryAllProvidersAttributesRequest
+);
+
 function createBaseQueryProviderAttributesRequest(): QueryProviderAttributesRequest {
-  return { owner: "", pagination: undefined };
+  return {
+    $type: "akash.audit.v1beta1.QueryProviderAttributesRequest",
+    owner: "",
+    pagination: undefined,
+  };
 }
 
 export const QueryProviderAttributesRequest = {
+  $type: "akash.audit.v1beta1.QueryProviderAttributesRequest" as const,
+
   encode(
     message: QueryProviderAttributesRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -305,6 +347,7 @@ export const QueryProviderAttributesRequest = {
 
   fromJSON(object: any): QueryProviderAttributesRequest {
     return {
+      $type: QueryProviderAttributesRequest.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       pagination: isSet(object.pagination)
         ? PageRequest.fromJSON(object.pagination)
@@ -335,11 +378,22 @@ export const QueryProviderAttributesRequest = {
   },
 };
 
+messageTypeRegistry.set(
+  QueryProviderAttributesRequest.$type,
+  QueryProviderAttributesRequest
+);
+
 function createBaseQueryProviderAuditorRequest(): QueryProviderAuditorRequest {
-  return { auditor: "", owner: "" };
+  return {
+    $type: "akash.audit.v1beta1.QueryProviderAuditorRequest",
+    auditor: "",
+    owner: "",
+  };
 }
 
 export const QueryProviderAuditorRequest = {
+  $type: "akash.audit.v1beta1.QueryProviderAuditorRequest" as const,
+
   encode(
     message: QueryProviderAuditorRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -379,6 +433,7 @@ export const QueryProviderAuditorRequest = {
 
   fromJSON(object: any): QueryProviderAuditorRequest {
     return {
+      $type: QueryProviderAuditorRequest.$type,
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       owner: isSet(object.owner) ? String(object.owner) : "",
     };
@@ -401,11 +456,22 @@ export const QueryProviderAuditorRequest = {
   },
 };
 
+messageTypeRegistry.set(
+  QueryProviderAuditorRequest.$type,
+  QueryProviderAuditorRequest
+);
+
 function createBaseQueryAuditorAttributesRequest(): QueryAuditorAttributesRequest {
-  return { auditor: "", pagination: undefined };
+  return {
+    $type: "akash.audit.v1beta1.QueryAuditorAttributesRequest",
+    auditor: "",
+    pagination: undefined,
+  };
 }
 
 export const QueryAuditorAttributesRequest = {
+  $type: "akash.audit.v1beta1.QueryAuditorAttributesRequest" as const,
+
   encode(
     message: QueryAuditorAttributesRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -445,6 +511,7 @@ export const QueryAuditorAttributesRequest = {
 
   fromJSON(object: any): QueryAuditorAttributesRequest {
     return {
+      $type: QueryAuditorAttributesRequest.$type,
       auditor: isSet(object.auditor) ? String(object.auditor) : "",
       pagination: isSet(object.pagination)
         ? PageRequest.fromJSON(object.pagination)
@@ -474,6 +541,11 @@ export const QueryAuditorAttributesRequest = {
     return message;
   },
 };
+
+messageTypeRegistry.set(
+  QueryAuditorAttributesRequest.$type,
+  QueryAuditorAttributesRequest
+);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -603,14 +675,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/base/v1beta1/attribute.ts
+++ b/src/protobuf/akash/base/v1beta1/attribute.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -6,6 +7,7 @@ export const protobufPackage = "akash.base.v1beta1";
 
 /** Attribute represents key value pair */
 export interface Attribute {
+  $type: "akash.base.v1beta1.Attribute";
   key: string;
   value: string;
 }
@@ -17,6 +19,7 @@ export interface Attribute {
  * this behaviour to be discussed
  */
 export interface SignedBy {
+  $type: "akash.base.v1beta1.SignedBy";
   /** all_of all keys in this list must have signed attributes */
   allOf: string[];
   /** any_of at least of of the keys from the list must have signed attributes */
@@ -25,6 +28,7 @@ export interface SignedBy {
 
 /** PlacementRequirements */
 export interface PlacementRequirements {
+  $type: "akash.base.v1beta1.PlacementRequirements";
   /** SignedBy list of keys that tenants expect to have signatures from */
   signedBy?: SignedBy;
   /** Attribute list of attributes tenant expects from the provider */
@@ -32,10 +36,12 @@ export interface PlacementRequirements {
 }
 
 function createBaseAttribute(): Attribute {
-  return { key: "", value: "" };
+  return { $type: "akash.base.v1beta1.Attribute", key: "", value: "" };
 }
 
 export const Attribute = {
+  $type: "akash.base.v1beta1.Attribute" as const,
+
   encode(
     message: Attribute,
     writer: _m0.Writer = _m0.Writer.create()
@@ -72,6 +78,7 @@ export const Attribute = {
 
   fromJSON(object: any): Attribute {
     return {
+      $type: Attribute.$type,
       key: isSet(object.key) ? String(object.key) : "",
       value: isSet(object.value) ? String(object.value) : "",
     };
@@ -94,11 +101,15 @@ export const Attribute = {
   },
 };
 
+messageTypeRegistry.set(Attribute.$type, Attribute);
+
 function createBaseSignedBy(): SignedBy {
-  return { allOf: [], anyOf: [] };
+  return { $type: "akash.base.v1beta1.SignedBy", allOf: [], anyOf: [] };
 }
 
 export const SignedBy = {
+  $type: "akash.base.v1beta1.SignedBy" as const,
+
   encode(
     message: SignedBy,
     writer: _m0.Writer = _m0.Writer.create()
@@ -135,6 +146,7 @@ export const SignedBy = {
 
   fromJSON(object: any): SignedBy {
     return {
+      $type: SignedBy.$type,
       allOf: Array.isArray(object?.allOf)
         ? object.allOf.map((e: any) => String(e))
         : [],
@@ -167,11 +179,19 @@ export const SignedBy = {
   },
 };
 
+messageTypeRegistry.set(SignedBy.$type, SignedBy);
+
 function createBasePlacementRequirements(): PlacementRequirements {
-  return { signedBy: undefined, attributes: [] };
+  return {
+    $type: "akash.base.v1beta1.PlacementRequirements",
+    signedBy: undefined,
+    attributes: [],
+  };
 }
 
 export const PlacementRequirements = {
+  $type: "akash.base.v1beta1.PlacementRequirements" as const,
+
   encode(
     message: PlacementRequirements,
     writer: _m0.Writer = _m0.Writer.create()
@@ -211,6 +231,7 @@ export const PlacementRequirements = {
 
   fromJSON(object: any): PlacementRequirements {
     return {
+      $type: PlacementRequirements.$type,
       signedBy: isSet(object.signedBy)
         ? SignedBy.fromJSON(object.signedBy)
         : undefined,
@@ -250,6 +271,8 @@ export const PlacementRequirements = {
   },
 };
 
+messageTypeRegistry.set(PlacementRequirements.$type, PlacementRequirements);
+
 type Builtin =
   | Date
   | Function
@@ -268,14 +291,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/base/v1beta1/endpoint.ts
+++ b/src/protobuf/akash/base/v1beta1/endpoint.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -6,6 +7,7 @@ export const protobufPackage = "akash.base.v1beta1";
 
 /** Endpoint describes a publicly accessible IP service */
 export interface Endpoint {
+  $type: "akash.base.v1beta1.Endpoint";
   kind: Endpoint_Kind;
 }
 
@@ -45,10 +47,12 @@ export function endpoint_KindToJSON(object: Endpoint_Kind): string {
 }
 
 function createBaseEndpoint(): Endpoint {
-  return { kind: 0 };
+  return { $type: "akash.base.v1beta1.Endpoint", kind: 0 };
 }
 
 export const Endpoint = {
+  $type: "akash.base.v1beta1.Endpoint" as const,
+
   encode(
     message: Endpoint,
     writer: _m0.Writer = _m0.Writer.create()
@@ -79,6 +83,7 @@ export const Endpoint = {
 
   fromJSON(object: any): Endpoint {
     return {
+      $type: Endpoint.$type,
       kind: isSet(object.kind) ? endpoint_KindFromJSON(object.kind) : 0,
     };
   },
@@ -96,6 +101,8 @@ export const Endpoint = {
     return message;
   },
 };
+
+messageTypeRegistry.set(Endpoint.$type, Endpoint);
 
 type Builtin =
   | Date
@@ -115,14 +122,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/base/v1beta1/resource.ts
+++ b/src/protobuf/akash/base/v1beta1/resource.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { ResourceValue } from "../../../akash/base/v1beta1/resourcevalue";
@@ -9,18 +10,21 @@ export const protobufPackage = "akash.base.v1beta1";
 
 /** CPU stores resource units and cpu config attributes */
 export interface CPU {
+  $type: "akash.base.v1beta1.CPU";
   units?: ResourceValue;
   attributes: Attribute[];
 }
 
 /** Memory stores resource quantity and memory attributes */
 export interface Memory {
+  $type: "akash.base.v1beta1.Memory";
   quantity?: ResourceValue;
   attributes: Attribute[];
 }
 
 /** Storage stores resource quantity and storage attributes */
 export interface Storage {
+  $type: "akash.base.v1beta1.Storage";
   quantity?: ResourceValue;
   attributes: Attribute[];
 }
@@ -30,6 +34,7 @@ export interface Storage {
  * if field is nil resource is not present in the given data-structure
  */
 export interface ResourceUnits {
+  $type: "akash.base.v1beta1.ResourceUnits";
   cpu?: CPU;
   memory?: Memory;
   storage?: Storage;
@@ -37,10 +42,12 @@ export interface ResourceUnits {
 }
 
 function createBaseCPU(): CPU {
-  return { units: undefined, attributes: [] };
+  return { $type: "akash.base.v1beta1.CPU", units: undefined, attributes: [] };
 }
 
 export const CPU = {
+  $type: "akash.base.v1beta1.CPU" as const,
+
   encode(message: CPU, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.units !== undefined) {
       ResourceValue.encode(message.units, writer.uint32(10).fork()).ldelim();
@@ -74,6 +81,7 @@ export const CPU = {
 
   fromJSON(object: any): CPU {
     return {
+      $type: CPU.$type,
       units: isSet(object.units)
         ? ResourceValue.fromJSON(object.units)
         : undefined,
@@ -111,11 +119,19 @@ export const CPU = {
   },
 };
 
+messageTypeRegistry.set(CPU.$type, CPU);
+
 function createBaseMemory(): Memory {
-  return { quantity: undefined, attributes: [] };
+  return {
+    $type: "akash.base.v1beta1.Memory",
+    quantity: undefined,
+    attributes: [],
+  };
 }
 
 export const Memory = {
+  $type: "akash.base.v1beta1.Memory" as const,
+
   encode(
     message: Memory,
     writer: _m0.Writer = _m0.Writer.create()
@@ -152,6 +168,7 @@ export const Memory = {
 
   fromJSON(object: any): Memory {
     return {
+      $type: Memory.$type,
       quantity: isSet(object.quantity)
         ? ResourceValue.fromJSON(object.quantity)
         : undefined,
@@ -189,11 +206,19 @@ export const Memory = {
   },
 };
 
+messageTypeRegistry.set(Memory.$type, Memory);
+
 function createBaseStorage(): Storage {
-  return { quantity: undefined, attributes: [] };
+  return {
+    $type: "akash.base.v1beta1.Storage",
+    quantity: undefined,
+    attributes: [],
+  };
 }
 
 export const Storage = {
+  $type: "akash.base.v1beta1.Storage" as const,
+
   encode(
     message: Storage,
     writer: _m0.Writer = _m0.Writer.create()
@@ -230,6 +255,7 @@ export const Storage = {
 
   fromJSON(object: any): Storage {
     return {
+      $type: Storage.$type,
       quantity: isSet(object.quantity)
         ? ResourceValue.fromJSON(object.quantity)
         : undefined,
@@ -267,8 +293,11 @@ export const Storage = {
   },
 };
 
+messageTypeRegistry.set(Storage.$type, Storage);
+
 function createBaseResourceUnits(): ResourceUnits {
   return {
+    $type: "akash.base.v1beta1.ResourceUnits",
     cpu: undefined,
     memory: undefined,
     storage: undefined,
@@ -277,6 +306,8 @@ function createBaseResourceUnits(): ResourceUnits {
 }
 
 export const ResourceUnits = {
+  $type: "akash.base.v1beta1.ResourceUnits" as const,
+
   encode(
     message: ResourceUnits,
     writer: _m0.Writer = _m0.Writer.create()
@@ -325,6 +356,7 @@ export const ResourceUnits = {
 
   fromJSON(object: any): ResourceUnits {
     return {
+      $type: ResourceUnits.$type,
       cpu: isSet(object.cpu) ? CPU.fromJSON(object.cpu) : undefined,
       memory: isSet(object.memory) ? Memory.fromJSON(object.memory) : undefined,
       storage: isSet(object.storage)
@@ -378,6 +410,8 @@ export const ResourceUnits = {
   },
 };
 
+messageTypeRegistry.set(ResourceUnits.$type, ResourceUnits);
+
 type Builtin =
   | Date
   | Function
@@ -396,14 +430,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/base/v1beta1/resourcevalue.ts
+++ b/src/protobuf/akash/base/v1beta1/resourcevalue.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -6,14 +7,17 @@ export const protobufPackage = "akash.base.v1beta1";
 
 /** Unit stores cpu, memory and storage metrics */
 export interface ResourceValue {
+  $type: "akash.base.v1beta1.ResourceValue";
   val: Uint8Array;
 }
 
 function createBaseResourceValue(): ResourceValue {
-  return { val: new Uint8Array() };
+  return { $type: "akash.base.v1beta1.ResourceValue", val: new Uint8Array() };
 }
 
 export const ResourceValue = {
+  $type: "akash.base.v1beta1.ResourceValue" as const,
+
   encode(
     message: ResourceValue,
     writer: _m0.Writer = _m0.Writer.create()
@@ -44,6 +48,7 @@ export const ResourceValue = {
 
   fromJSON(object: any): ResourceValue {
     return {
+      $type: ResourceValue.$type,
       val: isSet(object.val) ? bytesFromBase64(object.val) : new Uint8Array(),
     };
   },
@@ -65,6 +70,8 @@ export const ResourceValue = {
     return message;
   },
 };
+
+messageTypeRegistry.set(ResourceValue.$type, ResourceValue);
 
 declare var self: any | undefined;
 declare var window: any | undefined;
@@ -118,14 +125,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/cert/v1beta1/cert.ts
+++ b/src/protobuf/akash/cert/v1beta1/cert.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -6,12 +7,14 @@ export const protobufPackage = "akash.cert.v1beta1";
 
 /** CertificateID stores owner and sequence number */
 export interface CertificateID {
+  $type: "akash.cert.v1beta1.CertificateID";
   owner: string;
   serial: string;
 }
 
 /** Certificate stores state, certificate and it's public key */
 export interface Certificate {
+  $type: "akash.cert.v1beta1.Certificate";
   state: Certificate_State;
   cert: Uint8Array;
   pubkey: Uint8Array;
@@ -61,6 +64,7 @@ export function certificate_StateToJSON(object: Certificate_State): string {
 
 /** CertificateFilter defines filters used to filter certificates */
 export interface CertificateFilter {
+  $type: "akash.cert.v1beta1.CertificateFilter";
   owner: string;
   serial: string;
   state: string;
@@ -68,27 +72,35 @@ export interface CertificateFilter {
 
 /** MsgCreateCertificate defines an SDK message for creating certificate */
 export interface MsgCreateCertificate {
+  $type: "akash.cert.v1beta1.MsgCreateCertificate";
   owner: string;
   cert: Uint8Array;
   pubkey: Uint8Array;
 }
 
 /** MsgCreateCertificateResponse defines the Msg/CreateCertificate response type. */
-export interface MsgCreateCertificateResponse {}
+export interface MsgCreateCertificateResponse {
+  $type: "akash.cert.v1beta1.MsgCreateCertificateResponse";
+}
 
 /** MsgRevokeCertificate defines an SDK message for revoking certificate */
 export interface MsgRevokeCertificate {
+  $type: "akash.cert.v1beta1.MsgRevokeCertificate";
   id?: CertificateID;
 }
 
 /** MsgRevokeCertificateResponse defines the Msg/RevokeCertificate response type. */
-export interface MsgRevokeCertificateResponse {}
+export interface MsgRevokeCertificateResponse {
+  $type: "akash.cert.v1beta1.MsgRevokeCertificateResponse";
+}
 
 function createBaseCertificateID(): CertificateID {
-  return { owner: "", serial: "" };
+  return { $type: "akash.cert.v1beta1.CertificateID", owner: "", serial: "" };
 }
 
 export const CertificateID = {
+  $type: "akash.cert.v1beta1.CertificateID" as const,
+
   encode(
     message: CertificateID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -125,6 +137,7 @@ export const CertificateID = {
 
   fromJSON(object: any): CertificateID {
     return {
+      $type: CertificateID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       serial: isSet(object.serial) ? String(object.serial) : "",
     };
@@ -147,11 +160,20 @@ export const CertificateID = {
   },
 };
 
+messageTypeRegistry.set(CertificateID.$type, CertificateID);
+
 function createBaseCertificate(): Certificate {
-  return { state: 0, cert: new Uint8Array(), pubkey: new Uint8Array() };
+  return {
+    $type: "akash.cert.v1beta1.Certificate",
+    state: 0,
+    cert: new Uint8Array(),
+    pubkey: new Uint8Array(),
+  };
 }
 
 export const Certificate = {
+  $type: "akash.cert.v1beta1.Certificate" as const,
+
   encode(
     message: Certificate,
     writer: _m0.Writer = _m0.Writer.create()
@@ -194,6 +216,7 @@ export const Certificate = {
 
   fromJSON(object: any): Certificate {
     return {
+      $type: Certificate.$type,
       state: isSet(object.state) ? certificate_StateFromJSON(object.state) : 0,
       cert: isSet(object.cert)
         ? bytesFromBase64(object.cert)
@@ -230,11 +253,20 @@ export const Certificate = {
   },
 };
 
+messageTypeRegistry.set(Certificate.$type, Certificate);
+
 function createBaseCertificateFilter(): CertificateFilter {
-  return { owner: "", serial: "", state: "" };
+  return {
+    $type: "akash.cert.v1beta1.CertificateFilter",
+    owner: "",
+    serial: "",
+    state: "",
+  };
 }
 
 export const CertificateFilter = {
+  $type: "akash.cert.v1beta1.CertificateFilter" as const,
+
   encode(
     message: CertificateFilter,
     writer: _m0.Writer = _m0.Writer.create()
@@ -277,6 +309,7 @@ export const CertificateFilter = {
 
   fromJSON(object: any): CertificateFilter {
     return {
+      $type: CertificateFilter.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       serial: isSet(object.serial) ? String(object.serial) : "",
       state: isSet(object.state) ? String(object.state) : "",
@@ -302,11 +335,20 @@ export const CertificateFilter = {
   },
 };
 
+messageTypeRegistry.set(CertificateFilter.$type, CertificateFilter);
+
 function createBaseMsgCreateCertificate(): MsgCreateCertificate {
-  return { owner: "", cert: new Uint8Array(), pubkey: new Uint8Array() };
+  return {
+    $type: "akash.cert.v1beta1.MsgCreateCertificate",
+    owner: "",
+    cert: new Uint8Array(),
+    pubkey: new Uint8Array(),
+  };
 }
 
 export const MsgCreateCertificate = {
+  $type: "akash.cert.v1beta1.MsgCreateCertificate" as const,
+
   encode(
     message: MsgCreateCertificate,
     writer: _m0.Writer = _m0.Writer.create()
@@ -352,6 +394,7 @@ export const MsgCreateCertificate = {
 
   fromJSON(object: any): MsgCreateCertificate {
     return {
+      $type: MsgCreateCertificate.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       cert: isSet(object.cert)
         ? bytesFromBase64(object.cert)
@@ -387,11 +430,15 @@ export const MsgCreateCertificate = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateCertificate.$type, MsgCreateCertificate);
+
 function createBaseMsgCreateCertificateResponse(): MsgCreateCertificateResponse {
-  return {};
+  return { $type: "akash.cert.v1beta1.MsgCreateCertificateResponse" };
 }
 
 export const MsgCreateCertificateResponse = {
+  $type: "akash.cert.v1beta1.MsgCreateCertificateResponse" as const,
+
   encode(
     _: MsgCreateCertificateResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -418,7 +465,9 @@ export const MsgCreateCertificateResponse = {
   },
 
   fromJSON(_: any): MsgCreateCertificateResponse {
-    return {};
+    return {
+      $type: MsgCreateCertificateResponse.$type,
+    };
   },
 
   toJSON(_: MsgCreateCertificateResponse): unknown {
@@ -434,11 +483,18 @@ export const MsgCreateCertificateResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgCreateCertificateResponse.$type,
+  MsgCreateCertificateResponse
+);
+
 function createBaseMsgRevokeCertificate(): MsgRevokeCertificate {
-  return { id: undefined };
+  return { $type: "akash.cert.v1beta1.MsgRevokeCertificate", id: undefined };
 }
 
 export const MsgRevokeCertificate = {
+  $type: "akash.cert.v1beta1.MsgRevokeCertificate" as const,
+
   encode(
     message: MsgRevokeCertificate,
     writer: _m0.Writer = _m0.Writer.create()
@@ -472,6 +528,7 @@ export const MsgRevokeCertificate = {
 
   fromJSON(object: any): MsgRevokeCertificate {
     return {
+      $type: MsgRevokeCertificate.$type,
       id: isSet(object.id) ? CertificateID.fromJSON(object.id) : undefined,
     };
   },
@@ -495,11 +552,15 @@ export const MsgRevokeCertificate = {
   },
 };
 
+messageTypeRegistry.set(MsgRevokeCertificate.$type, MsgRevokeCertificate);
+
 function createBaseMsgRevokeCertificateResponse(): MsgRevokeCertificateResponse {
-  return {};
+  return { $type: "akash.cert.v1beta1.MsgRevokeCertificateResponse" };
 }
 
 export const MsgRevokeCertificateResponse = {
+  $type: "akash.cert.v1beta1.MsgRevokeCertificateResponse" as const,
+
   encode(
     _: MsgRevokeCertificateResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -526,7 +587,9 @@ export const MsgRevokeCertificateResponse = {
   },
 
   fromJSON(_: any): MsgRevokeCertificateResponse {
-    return {};
+    return {
+      $type: MsgRevokeCertificateResponse.$type,
+    };
   },
 
   toJSON(_: MsgRevokeCertificateResponse): unknown {
@@ -541,6 +604,11 @@ export const MsgRevokeCertificateResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(
+  MsgRevokeCertificateResponse.$type,
+  MsgRevokeCertificateResponse
+);
 
 /** Msg defines the provider Msg service */
 export interface Msg {
@@ -650,14 +718,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/cert/v1beta1/genesis.ts
+++ b/src/protobuf/akash/cert/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Certificate } from "../../../akash/cert/v1beta1/cert";
@@ -7,20 +8,28 @@ export const protobufPackage = "akash.cert.v1beta1";
 
 /** GenesisCertificate defines certificate entry at genesis */
 export interface GenesisCertificate {
+  $type: "akash.cert.v1beta1.GenesisCertificate";
   owner: string;
   certificate?: Certificate;
 }
 
 /** GenesisState defines the basic genesis state used by cert module */
 export interface GenesisState {
+  $type: "akash.cert.v1beta1.GenesisState";
   certificates: GenesisCertificate[];
 }
 
 function createBaseGenesisCertificate(): GenesisCertificate {
-  return { owner: "", certificate: undefined };
+  return {
+    $type: "akash.cert.v1beta1.GenesisCertificate",
+    owner: "",
+    certificate: undefined,
+  };
 }
 
 export const GenesisCertificate = {
+  $type: "akash.cert.v1beta1.GenesisCertificate" as const,
+
   encode(
     message: GenesisCertificate,
     writer: _m0.Writer = _m0.Writer.create()
@@ -60,6 +69,7 @@ export const GenesisCertificate = {
 
   fromJSON(object: any): GenesisCertificate {
     return {
+      $type: GenesisCertificate.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       certificate: isSet(object.certificate)
         ? Certificate.fromJSON(object.certificate)
@@ -90,11 +100,15 @@ export const GenesisCertificate = {
   },
 };
 
+messageTypeRegistry.set(GenesisCertificate.$type, GenesisCertificate);
+
 function createBaseGenesisState(): GenesisState {
-  return { certificates: [] };
+  return { $type: "akash.cert.v1beta1.GenesisState", certificates: [] };
 }
 
 export const GenesisState = {
+  $type: "akash.cert.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -127,6 +141,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       certificates: Array.isArray(object?.certificates)
         ? object.certificates.map((e: any) => GenesisCertificate.fromJSON(e))
         : [],
@@ -155,6 +170,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -173,14 +190,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/cert/v1beta1/query.ts
+++ b/src/protobuf/akash/cert/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -13,27 +14,36 @@ import {
 export const protobufPackage = "akash.cert.v1beta1";
 
 export interface CertificateResponse {
+  $type: "akash.cert.v1beta1.CertificateResponse";
   certificate?: Certificate;
   serial: string;
 }
 
 /** QueryDeploymentsRequest is request type for the Query/Deployments RPC method */
 export interface QueryCertificatesRequest {
+  $type: "akash.cert.v1beta1.QueryCertificatesRequest";
   filter?: CertificateFilter;
   pagination?: PageRequest;
 }
 
 /** QueryCertificatesResponse is response type for the Query/Certificates RPC method */
 export interface QueryCertificatesResponse {
+  $type: "akash.cert.v1beta1.QueryCertificatesResponse";
   certificates: CertificateResponse[];
   pagination?: PageResponse;
 }
 
 function createBaseCertificateResponse(): CertificateResponse {
-  return { certificate: undefined, serial: "" };
+  return {
+    $type: "akash.cert.v1beta1.CertificateResponse",
+    certificate: undefined,
+    serial: "",
+  };
 }
 
 export const CertificateResponse = {
+  $type: "akash.cert.v1beta1.CertificateResponse" as const,
+
   encode(
     message: CertificateResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -73,6 +83,7 @@ export const CertificateResponse = {
 
   fromJSON(object: any): CertificateResponse {
     return {
+      $type: CertificateResponse.$type,
       certificate: isSet(object.certificate)
         ? Certificate.fromJSON(object.certificate)
         : undefined,
@@ -103,11 +114,19 @@ export const CertificateResponse = {
   },
 };
 
+messageTypeRegistry.set(CertificateResponse.$type, CertificateResponse);
+
 function createBaseQueryCertificatesRequest(): QueryCertificatesRequest {
-  return { filter: undefined, pagination: undefined };
+  return {
+    $type: "akash.cert.v1beta1.QueryCertificatesRequest",
+    filter: undefined,
+    pagination: undefined,
+  };
 }
 
 export const QueryCertificatesRequest = {
+  $type: "akash.cert.v1beta1.QueryCertificatesRequest" as const,
+
   encode(
     message: QueryCertificatesRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -150,6 +169,7 @@ export const QueryCertificatesRequest = {
 
   fromJSON(object: any): QueryCertificatesRequest {
     return {
+      $type: QueryCertificatesRequest.$type,
       filter: isSet(object.filter)
         ? CertificateFilter.fromJSON(object.filter)
         : undefined,
@@ -188,11 +208,22 @@ export const QueryCertificatesRequest = {
   },
 };
 
+messageTypeRegistry.set(
+  QueryCertificatesRequest.$type,
+  QueryCertificatesRequest
+);
+
 function createBaseQueryCertificatesResponse(): QueryCertificatesResponse {
-  return { certificates: [], pagination: undefined };
+  return {
+    $type: "akash.cert.v1beta1.QueryCertificatesResponse",
+    certificates: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryCertificatesResponse = {
+  $type: "akash.cert.v1beta1.QueryCertificatesResponse" as const,
+
   encode(
     message: QueryCertificatesResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -237,6 +268,7 @@ export const QueryCertificatesResponse = {
 
   fromJSON(object: any): QueryCertificatesResponse {
     return {
+      $type: QueryCertificatesResponse.$type,
       certificates: Array.isArray(object?.certificates)
         ? object.certificates.map((e: any) => CertificateResponse.fromJSON(e))
         : [],
@@ -275,6 +307,11 @@ export const QueryCertificatesResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(
+  QueryCertificatesResponse.$type,
+  QueryCertificatesResponse
+);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -331,14 +368,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/deployment/v1beta1/deployment.ts
+++ b/src/protobuf/akash/deployment/v1beta1/deployment.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Coin } from "../../../cosmos/base/v1beta1/coin";
@@ -16,6 +17,7 @@ export const protobufPackage = "akash.deployment.v1beta1";
 
 /** MsgCreateDeployment defines an SDK message for creating deployment */
 export interface MsgCreateDeployment {
+  $type: "akash.deployment.v1beta1.MsgCreateDeployment";
   id?: DeploymentID;
   groups: GroupSpec[];
   version: Uint8Array;
@@ -23,43 +25,56 @@ export interface MsgCreateDeployment {
 }
 
 /** MsgCreateDeploymentResponse defines the Msg/CreateDeployment response type. */
-export interface MsgCreateDeploymentResponse {}
+export interface MsgCreateDeploymentResponse {
+  $type: "akash.deployment.v1beta1.MsgCreateDeploymentResponse";
+}
 
 /** MsgDepositDeployment deposits more funds into the deposit account */
 export interface MsgDepositDeployment {
+  $type: "akash.deployment.v1beta1.MsgDepositDeployment";
   id?: DeploymentID;
   amount?: Coin;
 }
 
 /** MsgCreateDeploymentResponse defines the Msg/CreateDeployment response type. */
-export interface MsgDepositDeploymentResponse {}
+export interface MsgDepositDeploymentResponse {
+  $type: "akash.deployment.v1beta1.MsgDepositDeploymentResponse";
+}
 
 /** MsgUpdateDeployment defines an SDK message for updating deployment */
 export interface MsgUpdateDeployment {
+  $type: "akash.deployment.v1beta1.MsgUpdateDeployment";
   id?: DeploymentID;
   groups: GroupSpec[];
   version: Uint8Array;
 }
 
 /** MsgUpdateDeploymentResponse defines the Msg/UpdateDeployment response type. */
-export interface MsgUpdateDeploymentResponse {}
+export interface MsgUpdateDeploymentResponse {
+  $type: "akash.deployment.v1beta1.MsgUpdateDeploymentResponse";
+}
 
 /** MsgCloseDeployment defines an SDK message for closing deployment */
 export interface MsgCloseDeployment {
+  $type: "akash.deployment.v1beta1.MsgCloseDeployment";
   id?: DeploymentID;
 }
 
 /** MsgCloseDeploymentResponse defines the Msg/CloseDeployment response type. */
-export interface MsgCloseDeploymentResponse {}
+export interface MsgCloseDeploymentResponse {
+  $type: "akash.deployment.v1beta1.MsgCloseDeploymentResponse";
+}
 
 /** DeploymentID stores owner and sequence number */
 export interface DeploymentID {
+  $type: "akash.deployment.v1beta1.DeploymentID";
   owner: string;
   dseq: Long;
 }
 
 /** Deployment stores deploymentID, state and version details */
 export interface Deployment {
+  $type: "akash.deployment.v1beta1.Deployment";
   deploymentId?: DeploymentID;
   state: Deployment_State;
   version: Uint8Array;
@@ -110,6 +125,7 @@ export function deployment_StateToJSON(object: Deployment_State): string {
 
 /** DeploymentFilters defines filters used to filter deployments */
 export interface DeploymentFilters {
+  $type: "akash.deployment.v1beta1.DeploymentFilters";
   owner: string;
   dseq: Long;
   state: string;
@@ -117,6 +133,7 @@ export interface DeploymentFilters {
 
 function createBaseMsgCreateDeployment(): MsgCreateDeployment {
   return {
+    $type: "akash.deployment.v1beta1.MsgCreateDeployment",
     id: undefined,
     groups: [],
     version: new Uint8Array(),
@@ -125,6 +142,8 @@ function createBaseMsgCreateDeployment(): MsgCreateDeployment {
 }
 
 export const MsgCreateDeployment = {
+  $type: "akash.deployment.v1beta1.MsgCreateDeployment" as const,
+
   encode(
     message: MsgCreateDeployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -173,6 +192,7 @@ export const MsgCreateDeployment = {
 
   fromJSON(object: any): MsgCreateDeployment {
     return {
+      $type: MsgCreateDeployment.$type,
       id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
       groups: Array.isArray(object?.groups)
         ? object.groups.map((e: any) => GroupSpec.fromJSON(e))
@@ -226,11 +246,15 @@ export const MsgCreateDeployment = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateDeployment.$type, MsgCreateDeployment);
+
 function createBaseMsgCreateDeploymentResponse(): MsgCreateDeploymentResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgCreateDeploymentResponse" };
 }
 
 export const MsgCreateDeploymentResponse = {
+  $type: "akash.deployment.v1beta1.MsgCreateDeploymentResponse" as const,
+
   encode(
     _: MsgCreateDeploymentResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -257,7 +281,9 @@ export const MsgCreateDeploymentResponse = {
   },
 
   fromJSON(_: any): MsgCreateDeploymentResponse {
-    return {};
+    return {
+      $type: MsgCreateDeploymentResponse.$type,
+    };
   },
 
   toJSON(_: MsgCreateDeploymentResponse): unknown {
@@ -273,11 +299,22 @@ export const MsgCreateDeploymentResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgCreateDeploymentResponse.$type,
+  MsgCreateDeploymentResponse
+);
+
 function createBaseMsgDepositDeployment(): MsgDepositDeployment {
-  return { id: undefined, amount: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.MsgDepositDeployment",
+    id: undefined,
+    amount: undefined,
+  };
 }
 
 export const MsgDepositDeployment = {
+  $type: "akash.deployment.v1beta1.MsgDepositDeployment" as const,
+
   encode(
     message: MsgDepositDeployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -317,6 +354,7 @@ export const MsgDepositDeployment = {
 
   fromJSON(object: any): MsgDepositDeployment {
     return {
+      $type: MsgDepositDeployment.$type,
       id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
       amount: isSet(object.amount) ? Coin.fromJSON(object.amount) : undefined,
     };
@@ -347,11 +385,15 @@ export const MsgDepositDeployment = {
   },
 };
 
+messageTypeRegistry.set(MsgDepositDeployment.$type, MsgDepositDeployment);
+
 function createBaseMsgDepositDeploymentResponse(): MsgDepositDeploymentResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgDepositDeploymentResponse" };
 }
 
 export const MsgDepositDeploymentResponse = {
+  $type: "akash.deployment.v1beta1.MsgDepositDeploymentResponse" as const,
+
   encode(
     _: MsgDepositDeploymentResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -378,7 +420,9 @@ export const MsgDepositDeploymentResponse = {
   },
 
   fromJSON(_: any): MsgDepositDeploymentResponse {
-    return {};
+    return {
+      $type: MsgDepositDeploymentResponse.$type,
+    };
   },
 
   toJSON(_: MsgDepositDeploymentResponse): unknown {
@@ -394,11 +438,23 @@ export const MsgDepositDeploymentResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgDepositDeploymentResponse.$type,
+  MsgDepositDeploymentResponse
+);
+
 function createBaseMsgUpdateDeployment(): MsgUpdateDeployment {
-  return { id: undefined, groups: [], version: new Uint8Array() };
+  return {
+    $type: "akash.deployment.v1beta1.MsgUpdateDeployment",
+    id: undefined,
+    groups: [],
+    version: new Uint8Array(),
+  };
 }
 
 export const MsgUpdateDeployment = {
+  $type: "akash.deployment.v1beta1.MsgUpdateDeployment" as const,
+
   encode(
     message: MsgUpdateDeployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -441,6 +497,7 @@ export const MsgUpdateDeployment = {
 
   fromJSON(object: any): MsgUpdateDeployment {
     return {
+      $type: MsgUpdateDeployment.$type,
       id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
       groups: Array.isArray(object?.groups)
         ? object.groups.map((e: any) => GroupSpec.fromJSON(e))
@@ -483,11 +540,15 @@ export const MsgUpdateDeployment = {
   },
 };
 
+messageTypeRegistry.set(MsgUpdateDeployment.$type, MsgUpdateDeployment);
+
 function createBaseMsgUpdateDeploymentResponse(): MsgUpdateDeploymentResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgUpdateDeploymentResponse" };
 }
 
 export const MsgUpdateDeploymentResponse = {
+  $type: "akash.deployment.v1beta1.MsgUpdateDeploymentResponse" as const,
+
   encode(
     _: MsgUpdateDeploymentResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -514,7 +575,9 @@ export const MsgUpdateDeploymentResponse = {
   },
 
   fromJSON(_: any): MsgUpdateDeploymentResponse {
-    return {};
+    return {
+      $type: MsgUpdateDeploymentResponse.$type,
+    };
   },
 
   toJSON(_: MsgUpdateDeploymentResponse): unknown {
@@ -530,11 +593,21 @@ export const MsgUpdateDeploymentResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgUpdateDeploymentResponse.$type,
+  MsgUpdateDeploymentResponse
+);
+
 function createBaseMsgCloseDeployment(): MsgCloseDeployment {
-  return { id: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.MsgCloseDeployment",
+    id: undefined,
+  };
 }
 
 export const MsgCloseDeployment = {
+  $type: "akash.deployment.v1beta1.MsgCloseDeployment" as const,
+
   encode(
     message: MsgCloseDeployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -565,6 +638,7 @@ export const MsgCloseDeployment = {
 
   fromJSON(object: any): MsgCloseDeployment {
     return {
+      $type: MsgCloseDeployment.$type,
       id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
     };
   },
@@ -588,11 +662,15 @@ export const MsgCloseDeployment = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseDeployment.$type, MsgCloseDeployment);
+
 function createBaseMsgCloseDeploymentResponse(): MsgCloseDeploymentResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgCloseDeploymentResponse" };
 }
 
 export const MsgCloseDeploymentResponse = {
+  $type: "akash.deployment.v1beta1.MsgCloseDeploymentResponse" as const,
+
   encode(
     _: MsgCloseDeploymentResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -619,7 +697,9 @@ export const MsgCloseDeploymentResponse = {
   },
 
   fromJSON(_: any): MsgCloseDeploymentResponse {
-    return {};
+    return {
+      $type: MsgCloseDeploymentResponse.$type,
+    };
   },
 
   toJSON(_: MsgCloseDeploymentResponse): unknown {
@@ -635,11 +715,22 @@ export const MsgCloseDeploymentResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgCloseDeploymentResponse.$type,
+  MsgCloseDeploymentResponse
+);
+
 function createBaseDeploymentID(): DeploymentID {
-  return { owner: "", dseq: Long.UZERO };
+  return {
+    $type: "akash.deployment.v1beta1.DeploymentID",
+    owner: "",
+    dseq: Long.UZERO,
+  };
 }
 
 export const DeploymentID = {
+  $type: "akash.deployment.v1beta1.DeploymentID" as const,
+
   encode(
     message: DeploymentID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -676,6 +767,7 @@ export const DeploymentID = {
 
   fromJSON(object: any): DeploymentID {
     return {
+      $type: DeploymentID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
     };
@@ -702,8 +794,11 @@ export const DeploymentID = {
   },
 };
 
+messageTypeRegistry.set(DeploymentID.$type, DeploymentID);
+
 function createBaseDeployment(): Deployment {
   return {
+    $type: "akash.deployment.v1beta1.Deployment",
     deploymentId: undefined,
     state: 0,
     version: new Uint8Array(),
@@ -712,6 +807,8 @@ function createBaseDeployment(): Deployment {
 }
 
 export const Deployment = {
+  $type: "akash.deployment.v1beta1.Deployment" as const,
+
   encode(
     message: Deployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -763,6 +860,7 @@ export const Deployment = {
 
   fromJSON(object: any): Deployment {
     return {
+      $type: Deployment.$type,
       deploymentId: isSet(object.deploymentId)
         ? DeploymentID.fromJSON(object.deploymentId)
         : undefined,
@@ -811,11 +909,20 @@ export const Deployment = {
   },
 };
 
+messageTypeRegistry.set(Deployment.$type, Deployment);
+
 function createBaseDeploymentFilters(): DeploymentFilters {
-  return { owner: "", dseq: Long.UZERO, state: "" };
+  return {
+    $type: "akash.deployment.v1beta1.DeploymentFilters",
+    owner: "",
+    dseq: Long.UZERO,
+    state: "",
+  };
 }
 
 export const DeploymentFilters = {
+  $type: "akash.deployment.v1beta1.DeploymentFilters" as const,
+
   encode(
     message: DeploymentFilters,
     writer: _m0.Writer = _m0.Writer.create()
@@ -858,6 +965,7 @@ export const DeploymentFilters = {
 
   fromJSON(object: any): DeploymentFilters {
     return {
+      $type: DeploymentFilters.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       state: isSet(object.state) ? String(object.state) : "",
@@ -886,6 +994,8 @@ export const DeploymentFilters = {
     return message;
   },
 };
+
+messageTypeRegistry.set(DeploymentFilters.$type, DeploymentFilters);
 
 /** Msg defines the deployment Msg service. */
 export interface Msg {
@@ -1078,16 +1188,16 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+    Exclude<keyof I, KeysOfUnion<P> | "$type">,
+    never
+  >;
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/protobuf/akash/deployment/v1beta1/genesis.ts
+++ b/src/protobuf/akash/deployment/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Deployment } from "../../../akash/deployment/v1beta1/deployment";
@@ -9,21 +10,29 @@ export const protobufPackage = "akash.deployment.v1beta1";
 
 /** GenesisDeployment defines the basic genesis state used by deployment module */
 export interface GenesisDeployment {
+  $type: "akash.deployment.v1beta1.GenesisDeployment";
   deployment?: Deployment;
   groups: Group[];
 }
 
 /** GenesisState stores slice of genesis deployment instance */
 export interface GenesisState {
+  $type: "akash.deployment.v1beta1.GenesisState";
   deployments: GenesisDeployment[];
   params?: Params;
 }
 
 function createBaseGenesisDeployment(): GenesisDeployment {
-  return { deployment: undefined, groups: [] };
+  return {
+    $type: "akash.deployment.v1beta1.GenesisDeployment",
+    deployment: undefined,
+    groups: [],
+  };
 }
 
 export const GenesisDeployment = {
+  $type: "akash.deployment.v1beta1.GenesisDeployment" as const,
+
   encode(
     message: GenesisDeployment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -60,6 +69,7 @@ export const GenesisDeployment = {
 
   fromJSON(object: any): GenesisDeployment {
     return {
+      $type: GenesisDeployment.$type,
       deployment: isSet(object.deployment)
         ? Deployment.fromJSON(object.deployment)
         : undefined,
@@ -96,11 +106,19 @@ export const GenesisDeployment = {
   },
 };
 
+messageTypeRegistry.set(GenesisDeployment.$type, GenesisDeployment);
+
 function createBaseGenesisState(): GenesisState {
-  return { deployments: [], params: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.GenesisState",
+    deployments: [],
+    params: undefined,
+  };
 }
 
 export const GenesisState = {
+  $type: "akash.deployment.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -139,6 +157,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       deployments: Array.isArray(object?.deployments)
         ? object.deployments.map((e: any) => GenesisDeployment.fromJSON(e))
         : [],
@@ -174,6 +193,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -192,14 +213,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/deployment/v1beta1/group.ts
+++ b/src/protobuf/akash/deployment/v1beta1/group.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { PlacementRequirements } from "../../../akash/base/v1beta1/attribute";
@@ -9,30 +10,40 @@ export const protobufPackage = "akash.deployment.v1beta1";
 
 /** MsgCloseGroup defines SDK message to close a single Group within a Deployment. */
 export interface MsgCloseGroup {
+  $type: "akash.deployment.v1beta1.MsgCloseGroup";
   id?: GroupID;
 }
 
 /** MsgCloseGroupResponse defines the Msg/CloseGroup response type. */
-export interface MsgCloseGroupResponse {}
+export interface MsgCloseGroupResponse {
+  $type: "akash.deployment.v1beta1.MsgCloseGroupResponse";
+}
 
 /** MsgPauseGroup defines SDK message to close a single Group within a Deployment. */
 export interface MsgPauseGroup {
+  $type: "akash.deployment.v1beta1.MsgPauseGroup";
   id?: GroupID;
 }
 
 /** MsgPauseGroupResponse defines the Msg/PauseGroup response type. */
-export interface MsgPauseGroupResponse {}
+export interface MsgPauseGroupResponse {
+  $type: "akash.deployment.v1beta1.MsgPauseGroupResponse";
+}
 
 /** MsgStartGroup defines SDK message to close a single Group within a Deployment. */
 export interface MsgStartGroup {
+  $type: "akash.deployment.v1beta1.MsgStartGroup";
   id?: GroupID;
 }
 
 /** MsgStartGroupResponse defines the Msg/StartGroup response type. */
-export interface MsgStartGroupResponse {}
+export interface MsgStartGroupResponse {
+  $type: "akash.deployment.v1beta1.MsgStartGroupResponse";
+}
 
 /** GroupID stores owner, deployment sequence number and group sequence number */
 export interface GroupID {
+  $type: "akash.deployment.v1beta1.GroupID";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -40,6 +51,7 @@ export interface GroupID {
 
 /** GroupSpec stores group specifications */
 export interface GroupSpec {
+  $type: "akash.deployment.v1beta1.GroupSpec";
   name: string;
   requirements?: PlacementRequirements;
   resources: Resource[];
@@ -47,6 +59,7 @@ export interface GroupSpec {
 
 /** Group stores group id, state and specifications of group */
 export interface Group {
+  $type: "akash.deployment.v1beta1.Group";
   groupId?: GroupID;
   state: Group_State;
   groupSpec?: GroupSpec;
@@ -111,16 +124,19 @@ export function group_StateToJSON(object: Group_State): string {
 
 /** Resource stores unit, total count and price of resource */
 export interface Resource {
+  $type: "akash.deployment.v1beta1.Resource";
   resources?: ResourceUnits;
   count: number;
   price?: Coin;
 }
 
 function createBaseMsgCloseGroup(): MsgCloseGroup {
-  return { id: undefined };
+  return { $type: "akash.deployment.v1beta1.MsgCloseGroup", id: undefined };
 }
 
 export const MsgCloseGroup = {
+  $type: "akash.deployment.v1beta1.MsgCloseGroup" as const,
+
   encode(
     message: MsgCloseGroup,
     writer: _m0.Writer = _m0.Writer.create()
@@ -151,6 +167,7 @@ export const MsgCloseGroup = {
 
   fromJSON(object: any): MsgCloseGroup {
     return {
+      $type: MsgCloseGroup.$type,
       id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
     };
   },
@@ -174,11 +191,15 @@ export const MsgCloseGroup = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseGroup.$type, MsgCloseGroup);
+
 function createBaseMsgCloseGroupResponse(): MsgCloseGroupResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgCloseGroupResponse" };
 }
 
 export const MsgCloseGroupResponse = {
+  $type: "akash.deployment.v1beta1.MsgCloseGroupResponse" as const,
+
   encode(
     _: MsgCloseGroupResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -205,7 +226,9 @@ export const MsgCloseGroupResponse = {
   },
 
   fromJSON(_: any): MsgCloseGroupResponse {
-    return {};
+    return {
+      $type: MsgCloseGroupResponse.$type,
+    };
   },
 
   toJSON(_: MsgCloseGroupResponse): unknown {
@@ -221,11 +244,15 @@ export const MsgCloseGroupResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseGroupResponse.$type, MsgCloseGroupResponse);
+
 function createBaseMsgPauseGroup(): MsgPauseGroup {
-  return { id: undefined };
+  return { $type: "akash.deployment.v1beta1.MsgPauseGroup", id: undefined };
 }
 
 export const MsgPauseGroup = {
+  $type: "akash.deployment.v1beta1.MsgPauseGroup" as const,
+
   encode(
     message: MsgPauseGroup,
     writer: _m0.Writer = _m0.Writer.create()
@@ -256,6 +283,7 @@ export const MsgPauseGroup = {
 
   fromJSON(object: any): MsgPauseGroup {
     return {
+      $type: MsgPauseGroup.$type,
       id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
     };
   },
@@ -279,11 +307,15 @@ export const MsgPauseGroup = {
   },
 };
 
+messageTypeRegistry.set(MsgPauseGroup.$type, MsgPauseGroup);
+
 function createBaseMsgPauseGroupResponse(): MsgPauseGroupResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgPauseGroupResponse" };
 }
 
 export const MsgPauseGroupResponse = {
+  $type: "akash.deployment.v1beta1.MsgPauseGroupResponse" as const,
+
   encode(
     _: MsgPauseGroupResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -310,7 +342,9 @@ export const MsgPauseGroupResponse = {
   },
 
   fromJSON(_: any): MsgPauseGroupResponse {
-    return {};
+    return {
+      $type: MsgPauseGroupResponse.$type,
+    };
   },
 
   toJSON(_: MsgPauseGroupResponse): unknown {
@@ -326,11 +360,15 @@ export const MsgPauseGroupResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgPauseGroupResponse.$type, MsgPauseGroupResponse);
+
 function createBaseMsgStartGroup(): MsgStartGroup {
-  return { id: undefined };
+  return { $type: "akash.deployment.v1beta1.MsgStartGroup", id: undefined };
 }
 
 export const MsgStartGroup = {
+  $type: "akash.deployment.v1beta1.MsgStartGroup" as const,
+
   encode(
     message: MsgStartGroup,
     writer: _m0.Writer = _m0.Writer.create()
@@ -361,6 +399,7 @@ export const MsgStartGroup = {
 
   fromJSON(object: any): MsgStartGroup {
     return {
+      $type: MsgStartGroup.$type,
       id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
     };
   },
@@ -384,11 +423,15 @@ export const MsgStartGroup = {
   },
 };
 
+messageTypeRegistry.set(MsgStartGroup.$type, MsgStartGroup);
+
 function createBaseMsgStartGroupResponse(): MsgStartGroupResponse {
-  return {};
+  return { $type: "akash.deployment.v1beta1.MsgStartGroupResponse" };
 }
 
 export const MsgStartGroupResponse = {
+  $type: "akash.deployment.v1beta1.MsgStartGroupResponse" as const,
+
   encode(
     _: MsgStartGroupResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -415,7 +458,9 @@ export const MsgStartGroupResponse = {
   },
 
   fromJSON(_: any): MsgStartGroupResponse {
-    return {};
+    return {
+      $type: MsgStartGroupResponse.$type,
+    };
   },
 
   toJSON(_: MsgStartGroupResponse): unknown {
@@ -431,11 +476,20 @@ export const MsgStartGroupResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgStartGroupResponse.$type, MsgStartGroupResponse);
+
 function createBaseGroupID(): GroupID {
-  return { owner: "", dseq: Long.UZERO, gseq: 0 };
+  return {
+    $type: "akash.deployment.v1beta1.GroupID",
+    owner: "",
+    dseq: Long.UZERO,
+    gseq: 0,
+  };
 }
 
 export const GroupID = {
+  $type: "akash.deployment.v1beta1.GroupID" as const,
+
   encode(
     message: GroupID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -478,6 +532,7 @@ export const GroupID = {
 
   fromJSON(object: any): GroupID {
     return {
+      $type: GroupID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -505,11 +560,20 @@ export const GroupID = {
   },
 };
 
+messageTypeRegistry.set(GroupID.$type, GroupID);
+
 function createBaseGroupSpec(): GroupSpec {
-  return { name: "", requirements: undefined, resources: [] };
+  return {
+    $type: "akash.deployment.v1beta1.GroupSpec",
+    name: "",
+    requirements: undefined,
+    resources: [],
+  };
 }
 
 export const GroupSpec = {
+  $type: "akash.deployment.v1beta1.GroupSpec" as const,
+
   encode(
     message: GroupSpec,
     writer: _m0.Writer = _m0.Writer.create()
@@ -558,6 +622,7 @@ export const GroupSpec = {
 
   fromJSON(object: any): GroupSpec {
     return {
+      $type: GroupSpec.$type,
       name: isSet(object.name) ? String(object.name) : "",
       requirements: isSet(object.requirements)
         ? PlacementRequirements.fromJSON(object.requirements)
@@ -600,8 +665,11 @@ export const GroupSpec = {
   },
 };
 
+messageTypeRegistry.set(GroupSpec.$type, GroupSpec);
+
 function createBaseGroup(): Group {
   return {
+    $type: "akash.deployment.v1beta1.Group",
     groupId: undefined,
     state: 0,
     groupSpec: undefined,
@@ -610,6 +678,8 @@ function createBaseGroup(): Group {
 }
 
 export const Group = {
+  $type: "akash.deployment.v1beta1.Group" as const,
+
   encode(message: Group, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.groupId !== undefined) {
       GroupID.encode(message.groupId, writer.uint32(10).fork()).ldelim();
@@ -655,6 +725,7 @@ export const Group = {
 
   fromJSON(object: any): Group {
     return {
+      $type: Group.$type,
       groupId: isSet(object.groupId)
         ? GroupID.fromJSON(object.groupId)
         : undefined,
@@ -704,11 +775,20 @@ export const Group = {
   },
 };
 
+messageTypeRegistry.set(Group.$type, Group);
+
 function createBaseResource(): Resource {
-  return { resources: undefined, count: 0, price: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.Resource",
+    resources: undefined,
+    count: 0,
+    price: undefined,
+  };
 }
 
 export const Resource = {
+  $type: "akash.deployment.v1beta1.Resource" as const,
+
   encode(
     message: Resource,
     writer: _m0.Writer = _m0.Writer.create()
@@ -754,6 +834,7 @@ export const Resource = {
 
   fromJSON(object: any): Resource {
     return {
+      $type: Resource.$type,
       resources: isSet(object.resources)
         ? ResourceUnits.fromJSON(object.resources)
         : undefined,
@@ -789,6 +870,8 @@ export const Resource = {
   },
 };
 
+messageTypeRegistry.set(Resource.$type, Resource);
+
 type Builtin =
   | Date
   | Function
@@ -807,14 +890,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/deployment/v1beta1/params.ts
+++ b/src/protobuf/akash/deployment/v1beta1/params.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Coin } from "../../../cosmos/base/v1beta1/coin";
@@ -7,14 +8,20 @@ export const protobufPackage = "akash.deployment.v1beta1";
 
 /** Params defines the parameters for the x/deployment package */
 export interface Params {
+  $type: "akash.deployment.v1beta1.Params";
   deploymentMinDeposit?: Coin;
 }
 
 function createBaseParams(): Params {
-  return { deploymentMinDeposit: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.Params",
+    deploymentMinDeposit: undefined,
+  };
 }
 
 export const Params = {
+  $type: "akash.deployment.v1beta1.Params" as const,
+
   encode(
     message: Params,
     writer: _m0.Writer = _m0.Writer.create()
@@ -48,6 +55,7 @@ export const Params = {
 
   fromJSON(object: any): Params {
     return {
+      $type: Params.$type,
       deploymentMinDeposit: isSet(object.deploymentMinDeposit)
         ? Coin.fromJSON(object.deploymentMinDeposit)
         : undefined,
@@ -74,6 +82,8 @@ export const Params = {
   },
 };
 
+messageTypeRegistry.set(Params.$type, Params);
+
 type Builtin =
   | Date
   | Function
@@ -92,14 +102,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/deployment/v1beta1/query.ts
+++ b/src/protobuf/akash/deployment/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -17,23 +18,27 @@ export const protobufPackage = "akash.deployment.v1beta1";
 
 /** QueryDeploymentsRequest is request type for the Query/Deployments RPC method */
 export interface QueryDeploymentsRequest {
+  $type: "akash.deployment.v1beta1.QueryDeploymentsRequest";
   filters?: DeploymentFilters;
   pagination?: PageRequest;
 }
 
 /** QueryDeploymentsResponse is response type for the Query/Deployments RPC method */
 export interface QueryDeploymentsResponse {
+  $type: "akash.deployment.v1beta1.QueryDeploymentsResponse";
   deployments: QueryDeploymentResponse[];
   pagination?: PageResponse;
 }
 
 /** QueryDeploymentRequest is request type for the Query/Deployment RPC method */
 export interface QueryDeploymentRequest {
+  $type: "akash.deployment.v1beta1.QueryDeploymentRequest";
   id?: DeploymentID;
 }
 
 /** QueryDeploymentResponse is response type for the Query/Deployment RPC method */
 export interface QueryDeploymentResponse {
+  $type: "akash.deployment.v1beta1.QueryDeploymentResponse";
   deployment?: Deployment;
   groups: Group[];
   escrowAccount?: Account;
@@ -41,19 +46,27 @@ export interface QueryDeploymentResponse {
 
 /** QueryGroupRequest is request type for the Query/Group RPC method */
 export interface QueryGroupRequest {
+  $type: "akash.deployment.v1beta1.QueryGroupRequest";
   id?: GroupID;
 }
 
 /** QueryGroupResponse is response type for the Query/Group RPC method */
 export interface QueryGroupResponse {
+  $type: "akash.deployment.v1beta1.QueryGroupResponse";
   group?: Group;
 }
 
 function createBaseQueryDeploymentsRequest(): QueryDeploymentsRequest {
-  return { filters: undefined, pagination: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.QueryDeploymentsRequest",
+    filters: undefined,
+    pagination: undefined,
+  };
 }
 
 export const QueryDeploymentsRequest = {
+  $type: "akash.deployment.v1beta1.QueryDeploymentsRequest" as const,
+
   encode(
     message: QueryDeploymentsRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -96,6 +109,7 @@ export const QueryDeploymentsRequest = {
 
   fromJSON(object: any): QueryDeploymentsRequest {
     return {
+      $type: QueryDeploymentsRequest.$type,
       filters: isSet(object.filters)
         ? DeploymentFilters.fromJSON(object.filters)
         : undefined,
@@ -134,11 +148,19 @@ export const QueryDeploymentsRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryDeploymentsRequest.$type, QueryDeploymentsRequest);
+
 function createBaseQueryDeploymentsResponse(): QueryDeploymentsResponse {
-  return { deployments: [], pagination: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.QueryDeploymentsResponse",
+    deployments: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryDeploymentsResponse = {
+  $type: "akash.deployment.v1beta1.QueryDeploymentsResponse" as const,
+
   encode(
     message: QueryDeploymentsResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -183,6 +205,7 @@ export const QueryDeploymentsResponse = {
 
   fromJSON(object: any): QueryDeploymentsResponse {
     return {
+      $type: QueryDeploymentsResponse.$type,
       deployments: Array.isArray(object?.deployments)
         ? object.deployments.map((e: any) =>
             QueryDeploymentResponse.fromJSON(e)
@@ -225,11 +248,21 @@ export const QueryDeploymentsResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  QueryDeploymentsResponse.$type,
+  QueryDeploymentsResponse
+);
+
 function createBaseQueryDeploymentRequest(): QueryDeploymentRequest {
-  return { id: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.QueryDeploymentRequest",
+    id: undefined,
+  };
 }
 
 export const QueryDeploymentRequest = {
+  $type: "akash.deployment.v1beta1.QueryDeploymentRequest" as const,
+
   encode(
     message: QueryDeploymentRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -263,6 +296,7 @@ export const QueryDeploymentRequest = {
 
   fromJSON(object: any): QueryDeploymentRequest {
     return {
+      $type: QueryDeploymentRequest.$type,
       id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
     };
   },
@@ -286,11 +320,20 @@ export const QueryDeploymentRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryDeploymentRequest.$type, QueryDeploymentRequest);
+
 function createBaseQueryDeploymentResponse(): QueryDeploymentResponse {
-  return { deployment: undefined, groups: [], escrowAccount: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.QueryDeploymentResponse",
+    deployment: undefined,
+    groups: [],
+    escrowAccount: undefined,
+  };
 }
 
 export const QueryDeploymentResponse = {
+  $type: "akash.deployment.v1beta1.QueryDeploymentResponse" as const,
+
   encode(
     message: QueryDeploymentResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -336,6 +379,7 @@ export const QueryDeploymentResponse = {
 
   fromJSON(object: any): QueryDeploymentResponse {
     return {
+      $type: QueryDeploymentResponse.$type,
       deployment: isSet(object.deployment)
         ? Deployment.fromJSON(object.deployment)
         : undefined,
@@ -383,11 +427,15 @@ export const QueryDeploymentResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryDeploymentResponse.$type, QueryDeploymentResponse);
+
 function createBaseQueryGroupRequest(): QueryGroupRequest {
-  return { id: undefined };
+  return { $type: "akash.deployment.v1beta1.QueryGroupRequest", id: undefined };
 }
 
 export const QueryGroupRequest = {
+  $type: "akash.deployment.v1beta1.QueryGroupRequest" as const,
+
   encode(
     message: QueryGroupRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -418,6 +466,7 @@ export const QueryGroupRequest = {
 
   fromJSON(object: any): QueryGroupRequest {
     return {
+      $type: QueryGroupRequest.$type,
       id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
     };
   },
@@ -441,11 +490,18 @@ export const QueryGroupRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryGroupRequest.$type, QueryGroupRequest);
+
 function createBaseQueryGroupResponse(): QueryGroupResponse {
-  return { group: undefined };
+  return {
+    $type: "akash.deployment.v1beta1.QueryGroupResponse",
+    group: undefined,
+  };
 }
 
 export const QueryGroupResponse = {
+  $type: "akash.deployment.v1beta1.QueryGroupResponse" as const,
+
   encode(
     message: QueryGroupResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -476,6 +532,7 @@ export const QueryGroupResponse = {
 
   fromJSON(object: any): QueryGroupResponse {
     return {
+      $type: QueryGroupResponse.$type,
       group: isSet(object.group) ? Group.fromJSON(object.group) : undefined,
     };
   },
@@ -498,6 +555,8 @@ export const QueryGroupResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(QueryGroupResponse.$type, QueryGroupResponse);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -586,14 +645,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/escrow/v1beta1/genesis.ts
+++ b/src/protobuf/akash/escrow/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Account, Payment } from "../../../akash/escrow/v1beta1/types";
@@ -7,15 +8,22 @@ export const protobufPackage = "akash.escrow.v1beta1";
 
 /** GenesisState defines the basic genesis state used by escrow module */
 export interface GenesisState {
+  $type: "akash.escrow.v1beta1.GenesisState";
   accounts: Account[];
   payments: Payment[];
 }
 
 function createBaseGenesisState(): GenesisState {
-  return { accounts: [], payments: [] };
+  return {
+    $type: "akash.escrow.v1beta1.GenesisState",
+    accounts: [],
+    payments: [],
+  };
 }
 
 export const GenesisState = {
+  $type: "akash.escrow.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -52,6 +60,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       accounts: Array.isArray(object?.accounts)
         ? object.accounts.map((e: any) => Account.fromJSON(e))
         : [],
@@ -92,6 +101,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -110,14 +121,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/escrow/v1beta1/query.ts
+++ b/src/protobuf/akash/escrow/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -11,6 +12,7 @@ export const protobufPackage = "akash.escrow.v1beta1";
 
 /** QueryAccountRequest is request type for the Query/Account RPC method */
 export interface QueryAccountsRequest {
+  $type: "akash.escrow.v1beta1.QueryAccountsRequest";
   scope: string;
   xid: string;
   owner: string;
@@ -20,12 +22,14 @@ export interface QueryAccountsRequest {
 
 /** QueryProvidersResponse is response type for the Query/Providers RPC method */
 export interface QueryAccountsResponse {
+  $type: "akash.escrow.v1beta1.QueryAccountsResponse";
   accounts: Account[];
   pagination?: PageResponse;
 }
 
 /** QueryPaymentRequest is request type for the Query/Payment RPC method */
 export interface QueryPaymentsRequest {
+  $type: "akash.escrow.v1beta1.QueryPaymentsRequest";
   scope: string;
   xid: string;
   id: string;
@@ -36,15 +40,25 @@ export interface QueryPaymentsRequest {
 
 /** QueryProvidersResponse is response type for the Query/Providers RPC method */
 export interface QueryPaymentsResponse {
+  $type: "akash.escrow.v1beta1.QueryPaymentsResponse";
   payments: Payment[];
   pagination?: PageResponse;
 }
 
 function createBaseQueryAccountsRequest(): QueryAccountsRequest {
-  return { scope: "", xid: "", owner: "", state: "", pagination: undefined };
+  return {
+    $type: "akash.escrow.v1beta1.QueryAccountsRequest",
+    scope: "",
+    xid: "",
+    owner: "",
+    state: "",
+    pagination: undefined,
+  };
 }
 
 export const QueryAccountsRequest = {
+  $type: "akash.escrow.v1beta1.QueryAccountsRequest" as const,
+
   encode(
     message: QueryAccountsRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -102,6 +116,7 @@ export const QueryAccountsRequest = {
 
   fromJSON(object: any): QueryAccountsRequest {
     return {
+      $type: QueryAccountsRequest.$type,
       scope: isSet(object.scope) ? String(object.scope) : "",
       xid: isSet(object.xid) ? String(object.xid) : "",
       owner: isSet(object.owner) ? String(object.owner) : "",
@@ -141,11 +156,19 @@ export const QueryAccountsRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryAccountsRequest.$type, QueryAccountsRequest);
+
 function createBaseQueryAccountsResponse(): QueryAccountsResponse {
-  return { accounts: [], pagination: undefined };
+  return {
+    $type: "akash.escrow.v1beta1.QueryAccountsResponse",
+    accounts: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryAccountsResponse = {
+  $type: "akash.escrow.v1beta1.QueryAccountsResponse" as const,
+
   encode(
     message: QueryAccountsResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -188,6 +211,7 @@ export const QueryAccountsResponse = {
 
   fromJSON(object: any): QueryAccountsResponse {
     return {
+      $type: QueryAccountsResponse.$type,
       accounts: Array.isArray(object?.accounts)
         ? object.accounts.map((e: any) => Account.fromJSON(e))
         : [],
@@ -227,8 +251,11 @@ export const QueryAccountsResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryAccountsResponse.$type, QueryAccountsResponse);
+
 function createBaseQueryPaymentsRequest(): QueryPaymentsRequest {
   return {
+    $type: "akash.escrow.v1beta1.QueryPaymentsRequest",
     scope: "",
     xid: "",
     id: "",
@@ -239,6 +266,8 @@ function createBaseQueryPaymentsRequest(): QueryPaymentsRequest {
 }
 
 export const QueryPaymentsRequest = {
+  $type: "akash.escrow.v1beta1.QueryPaymentsRequest" as const,
+
   encode(
     message: QueryPaymentsRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -302,6 +331,7 @@ export const QueryPaymentsRequest = {
 
   fromJSON(object: any): QueryPaymentsRequest {
     return {
+      $type: QueryPaymentsRequest.$type,
       scope: isSet(object.scope) ? String(object.scope) : "",
       xid: isSet(object.xid) ? String(object.xid) : "",
       id: isSet(object.id) ? String(object.id) : "",
@@ -344,11 +374,19 @@ export const QueryPaymentsRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryPaymentsRequest.$type, QueryPaymentsRequest);
+
 function createBaseQueryPaymentsResponse(): QueryPaymentsResponse {
-  return { payments: [], pagination: undefined };
+  return {
+    $type: "akash.escrow.v1beta1.QueryPaymentsResponse",
+    payments: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryPaymentsResponse = {
+  $type: "akash.escrow.v1beta1.QueryPaymentsResponse" as const,
+
   encode(
     message: QueryPaymentsResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -391,6 +429,7 @@ export const QueryPaymentsResponse = {
 
   fromJSON(object: any): QueryPaymentsResponse {
     return {
+      $type: QueryPaymentsResponse.$type,
       payments: Array.isArray(object?.payments)
         ? object.payments.map((e: any) => Payment.fromJSON(e))
         : [],
@@ -429,6 +468,8 @@ export const QueryPaymentsResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(QueryPaymentsResponse.$type, QueryPaymentsResponse);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -504,14 +545,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/escrow/v1beta1/types.ts
+++ b/src/protobuf/akash/escrow/v1beta1/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Coin } from "../../../cosmos/base/v1beta1/coin";
@@ -7,12 +8,14 @@ export const protobufPackage = "akash.escrow.v1beta1";
 
 /** AccountID is the account identifier */
 export interface AccountID {
+  $type: "akash.escrow.v1beta1.AccountID";
   scope: string;
   xid: string;
 }
 
 /** Account stores state for an escrow account */
 export interface Account {
+  $type: "akash.escrow.v1beta1.Account";
   id?: AccountID;
   owner: string;
   state: Account_State;
@@ -72,6 +75,7 @@ export function account_StateToJSON(object: Account_State): string {
 
 /** Payment stores state for a payment */
 export interface Payment {
+  $type: "akash.escrow.v1beta1.Payment";
   accountId?: AccountID;
   paymentId: string;
   owner: string;
@@ -131,10 +135,12 @@ export function payment_StateToJSON(object: Payment_State): string {
 }
 
 function createBaseAccountID(): AccountID {
-  return { scope: "", xid: "" };
+  return { $type: "akash.escrow.v1beta1.AccountID", scope: "", xid: "" };
 }
 
 export const AccountID = {
+  $type: "akash.escrow.v1beta1.AccountID" as const,
+
   encode(
     message: AccountID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -171,6 +177,7 @@ export const AccountID = {
 
   fromJSON(object: any): AccountID {
     return {
+      $type: AccountID.$type,
       scope: isSet(object.scope) ? String(object.scope) : "",
       xid: isSet(object.xid) ? String(object.xid) : "",
     };
@@ -193,8 +200,11 @@ export const AccountID = {
   },
 };
 
+messageTypeRegistry.set(AccountID.$type, AccountID);
+
 function createBaseAccount(): Account {
   return {
+    $type: "akash.escrow.v1beta1.Account",
     id: undefined,
     owner: "",
     state: 0,
@@ -205,6 +215,8 @@ function createBaseAccount(): Account {
 }
 
 export const Account = {
+  $type: "akash.escrow.v1beta1.Account" as const,
+
   encode(
     message: Account,
     writer: _m0.Writer = _m0.Writer.create()
@@ -265,6 +277,7 @@ export const Account = {
 
   fromJSON(object: any): Account {
     return {
+      $type: Account.$type,
       id: isSet(object.id) ? AccountID.fromJSON(object.id) : undefined,
       owner: isSet(object.owner) ? String(object.owner) : "",
       state: isSet(object.state) ? account_StateFromJSON(object.state) : 0,
@@ -324,8 +337,11 @@ export const Account = {
   },
 };
 
+messageTypeRegistry.set(Account.$type, Account);
+
 function createBasePayment(): Payment {
   return {
+    $type: "akash.escrow.v1beta1.Payment",
     accountId: undefined,
     paymentId: "",
     owner: "",
@@ -337,6 +353,8 @@ function createBasePayment(): Payment {
 }
 
 export const Payment = {
+  $type: "akash.escrow.v1beta1.Payment" as const,
+
   encode(
     message: Payment,
     writer: _m0.Writer = _m0.Writer.create()
@@ -403,6 +421,7 @@ export const Payment = {
 
   fromJSON(object: any): Payment {
     return {
+      $type: Payment.$type,
       accountId: isSet(object.accountId)
         ? AccountID.fromJSON(object.accountId)
         : undefined,
@@ -467,6 +486,8 @@ export const Payment = {
   },
 };
 
+messageTypeRegistry.set(Payment.$type, Payment);
+
 type Builtin =
   | Date
   | Function
@@ -485,14 +506,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/bid.ts
+++ b/src/protobuf/akash/market/v1beta1/bid.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { OrderID } from "../../../akash/market/v1beta1/order";
@@ -8,6 +9,7 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** MsgCreateBid defines an SDK message for creating Bid */
 export interface MsgCreateBid {
+  $type: "akash.market.v1beta1.MsgCreateBid";
   order?: OrderID;
   provider: string;
   price?: Coin;
@@ -15,21 +17,27 @@ export interface MsgCreateBid {
 }
 
 /** MsgCreateBidResponse defines the Msg/CreateBid response type. */
-export interface MsgCreateBidResponse {}
+export interface MsgCreateBidResponse {
+  $type: "akash.market.v1beta1.MsgCreateBidResponse";
+}
 
 /** MsgCloseBid defines an SDK message for closing bid */
 export interface MsgCloseBid {
+  $type: "akash.market.v1beta1.MsgCloseBid";
   bidId?: BidID;
 }
 
 /** MsgCloseBidResponse defines the Msg/CloseBid response type. */
-export interface MsgCloseBidResponse {}
+export interface MsgCloseBidResponse {
+  $type: "akash.market.v1beta1.MsgCloseBidResponse";
+}
 
 /**
  * BidID stores owner and all other seq numbers
  * A successful bid becomes a Lease(ID).
  */
 export interface BidID {
+  $type: "akash.market.v1beta1.BidID";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -39,6 +47,7 @@ export interface BidID {
 
 /** Bid stores BidID, state of bid and price */
 export interface Bid {
+  $type: "akash.market.v1beta1.Bid";
   bidId?: BidID;
   state: Bid_State;
   price?: Coin;
@@ -103,6 +112,7 @@ export function bid_StateToJSON(object: Bid_State): string {
 
 /** BidFilters defines flags for bid list filter */
 export interface BidFilters {
+  $type: "akash.market.v1beta1.BidFilters";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -113,6 +123,7 @@ export interface BidFilters {
 
 function createBaseMsgCreateBid(): MsgCreateBid {
   return {
+    $type: "akash.market.v1beta1.MsgCreateBid",
     order: undefined,
     provider: "",
     price: undefined,
@@ -121,6 +132,8 @@ function createBaseMsgCreateBid(): MsgCreateBid {
 }
 
 export const MsgCreateBid = {
+  $type: "akash.market.v1beta1.MsgCreateBid" as const,
+
   encode(
     message: MsgCreateBid,
     writer: _m0.Writer = _m0.Writer.create()
@@ -169,6 +182,7 @@ export const MsgCreateBid = {
 
   fromJSON(object: any): MsgCreateBid {
     return {
+      $type: MsgCreateBid.$type,
       order: isSet(object.order) ? OrderID.fromJSON(object.order) : undefined,
       provider: isSet(object.provider) ? String(object.provider) : "",
       price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
@@ -213,11 +227,15 @@ export const MsgCreateBid = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateBid.$type, MsgCreateBid);
+
 function createBaseMsgCreateBidResponse(): MsgCreateBidResponse {
-  return {};
+  return { $type: "akash.market.v1beta1.MsgCreateBidResponse" };
 }
 
 export const MsgCreateBidResponse = {
+  $type: "akash.market.v1beta1.MsgCreateBidResponse" as const,
+
   encode(
     _: MsgCreateBidResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -244,7 +262,9 @@ export const MsgCreateBidResponse = {
   },
 
   fromJSON(_: any): MsgCreateBidResponse {
-    return {};
+    return {
+      $type: MsgCreateBidResponse.$type,
+    };
   },
 
   toJSON(_: MsgCreateBidResponse): unknown {
@@ -260,11 +280,15 @@ export const MsgCreateBidResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateBidResponse.$type, MsgCreateBidResponse);
+
 function createBaseMsgCloseBid(): MsgCloseBid {
-  return { bidId: undefined };
+  return { $type: "akash.market.v1beta1.MsgCloseBid", bidId: undefined };
 }
 
 export const MsgCloseBid = {
+  $type: "akash.market.v1beta1.MsgCloseBid" as const,
+
   encode(
     message: MsgCloseBid,
     writer: _m0.Writer = _m0.Writer.create()
@@ -295,6 +319,7 @@ export const MsgCloseBid = {
 
   fromJSON(object: any): MsgCloseBid {
     return {
+      $type: MsgCloseBid.$type,
       bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
     };
   },
@@ -318,11 +343,15 @@ export const MsgCloseBid = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseBid.$type, MsgCloseBid);
+
 function createBaseMsgCloseBidResponse(): MsgCloseBidResponse {
-  return {};
+  return { $type: "akash.market.v1beta1.MsgCloseBidResponse" };
 }
 
 export const MsgCloseBidResponse = {
+  $type: "akash.market.v1beta1.MsgCloseBidResponse" as const,
+
   encode(
     _: MsgCloseBidResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -346,7 +375,9 @@ export const MsgCloseBidResponse = {
   },
 
   fromJSON(_: any): MsgCloseBidResponse {
-    return {};
+    return {
+      $type: MsgCloseBidResponse.$type,
+    };
   },
 
   toJSON(_: MsgCloseBidResponse): unknown {
@@ -362,11 +393,22 @@ export const MsgCloseBidResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseBidResponse.$type, MsgCloseBidResponse);
+
 function createBaseBidID(): BidID {
-  return { owner: "", dseq: Long.UZERO, gseq: 0, oseq: 0, provider: "" };
+  return {
+    $type: "akash.market.v1beta1.BidID",
+    owner: "",
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: "",
+  };
 }
 
 export const BidID = {
+  $type: "akash.market.v1beta1.BidID" as const,
+
   encode(message: BidID, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.owner !== "") {
       writer.uint32(10).string(message.owner);
@@ -418,6 +460,7 @@ export const BidID = {
 
   fromJSON(object: any): BidID {
     return {
+      $type: BidID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -451,11 +494,21 @@ export const BidID = {
   },
 };
 
+messageTypeRegistry.set(BidID.$type, BidID);
+
 function createBaseBid(): Bid {
-  return { bidId: undefined, state: 0, price: undefined, createdAt: Long.ZERO };
+  return {
+    $type: "akash.market.v1beta1.Bid",
+    bidId: undefined,
+    state: 0,
+    price: undefined,
+    createdAt: Long.ZERO,
+  };
 }
 
 export const Bid = {
+  $type: "akash.market.v1beta1.Bid" as const,
+
   encode(message: Bid, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.bidId !== undefined) {
       BidID.encode(message.bidId, writer.uint32(10).fork()).ldelim();
@@ -501,6 +554,7 @@ export const Bid = {
 
   fromJSON(object: any): Bid {
     return {
+      $type: Bid.$type,
       bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
       state: isSet(object.state) ? bid_StateFromJSON(object.state) : 0,
       price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
@@ -541,8 +595,11 @@ export const Bid = {
   },
 };
 
+messageTypeRegistry.set(Bid.$type, Bid);
+
 function createBaseBidFilters(): BidFilters {
   return {
+    $type: "akash.market.v1beta1.BidFilters",
     owner: "",
     dseq: Long.UZERO,
     gseq: 0,
@@ -553,6 +610,8 @@ function createBaseBidFilters(): BidFilters {
 }
 
 export const BidFilters = {
+  $type: "akash.market.v1beta1.BidFilters" as const,
+
   encode(
     message: BidFilters,
     writer: _m0.Writer = _m0.Writer.create()
@@ -613,6 +672,7 @@ export const BidFilters = {
 
   fromJSON(object: any): BidFilters {
     return {
+      $type: BidFilters.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -651,6 +711,8 @@ export const BidFilters = {
   },
 };
 
+messageTypeRegistry.set(BidFilters.$type, BidFilters);
+
 type Builtin =
   | Date
   | Function
@@ -669,14 +731,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/genesis.ts
+++ b/src/protobuf/akash/market/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Params } from "../../../akash/market/v1beta1/params";
@@ -9,16 +10,24 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** GenesisState defines the basic genesis state used by market module */
 export interface GenesisState {
+  $type: "akash.market.v1beta1.GenesisState";
   orders: Order[];
   leases: Lease[];
   params?: Params;
 }
 
 function createBaseGenesisState(): GenesisState {
-  return { orders: [], leases: [], params: undefined };
+  return {
+    $type: "akash.market.v1beta1.GenesisState",
+    orders: [],
+    leases: [],
+    params: undefined,
+  };
 }
 
 export const GenesisState = {
+  $type: "akash.market.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -61,6 +70,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       orders: Array.isArray(object?.orders)
         ? object.orders.map((e: any) => Order.fromJSON(e))
         : [],
@@ -102,6 +112,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -120,14 +132,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/lease.ts
+++ b/src/protobuf/akash/market/v1beta1/lease.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Coin } from "../../../cosmos/base/v1beta1/coin";
@@ -8,6 +9,7 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** LeaseID stores bid details of lease */
 export interface LeaseID {
+  $type: "akash.market.v1beta1.LeaseID";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -17,6 +19,7 @@ export interface LeaseID {
 
 /** Lease stores LeaseID, state of lease and price */
 export interface Lease {
+  $type: "akash.market.v1beta1.Lease";
   leaseId?: LeaseID;
   state: Lease_State;
   price?: Coin;
@@ -74,6 +77,7 @@ export function lease_StateToJSON(object: Lease_State): string {
 
 /** LeaseFilters defines flags for lease list filter */
 export interface LeaseFilters {
+  $type: "akash.market.v1beta1.LeaseFilters";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -84,33 +88,51 @@ export interface LeaseFilters {
 
 /** MsgCreateLease is sent to create a lease */
 export interface MsgCreateLease {
+  $type: "akash.market.v1beta1.MsgCreateLease";
   bidId?: BidID;
 }
 
 /** MsgCreateLeaseResponse is the response from creating a lease */
-export interface MsgCreateLeaseResponse {}
+export interface MsgCreateLeaseResponse {
+  $type: "akash.market.v1beta1.MsgCreateLeaseResponse";
+}
 
 /** MsgWithdrawLease defines an SDK message for closing bid */
 export interface MsgWithdrawLease {
+  $type: "akash.market.v1beta1.MsgWithdrawLease";
   bidId?: LeaseID;
 }
 
 /** MsgWithdrawLeaseResponse defines the Msg/WithdrawLease response type. */
-export interface MsgWithdrawLeaseResponse {}
+export interface MsgWithdrawLeaseResponse {
+  $type: "akash.market.v1beta1.MsgWithdrawLeaseResponse";
+}
 
 /** MsgCloseLease defines an SDK message for closing order */
 export interface MsgCloseLease {
+  $type: "akash.market.v1beta1.MsgCloseLease";
   leaseId?: LeaseID;
 }
 
 /** MsgCloseLeaseResponse defines the Msg/CloseLease response type. */
-export interface MsgCloseLeaseResponse {}
+export interface MsgCloseLeaseResponse {
+  $type: "akash.market.v1beta1.MsgCloseLeaseResponse";
+}
 
 function createBaseLeaseID(): LeaseID {
-  return { owner: "", dseq: Long.UZERO, gseq: 0, oseq: 0, provider: "" };
+  return {
+    $type: "akash.market.v1beta1.LeaseID",
+    owner: "",
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: "",
+  };
 }
 
 export const LeaseID = {
+  $type: "akash.market.v1beta1.LeaseID" as const,
+
   encode(
     message: LeaseID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -165,6 +187,7 @@ export const LeaseID = {
 
   fromJSON(object: any): LeaseID {
     return {
+      $type: LeaseID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -198,8 +221,11 @@ export const LeaseID = {
   },
 };
 
+messageTypeRegistry.set(LeaseID.$type, LeaseID);
+
 function createBaseLease(): Lease {
   return {
+    $type: "akash.market.v1beta1.Lease",
     leaseId: undefined,
     state: 0,
     price: undefined,
@@ -208,6 +234,8 @@ function createBaseLease(): Lease {
 }
 
 export const Lease = {
+  $type: "akash.market.v1beta1.Lease" as const,
+
   encode(message: Lease, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.leaseId !== undefined) {
       LeaseID.encode(message.leaseId, writer.uint32(10).fork()).ldelim();
@@ -253,6 +281,7 @@ export const Lease = {
 
   fromJSON(object: any): Lease {
     return {
+      $type: Lease.$type,
       leaseId: isSet(object.leaseId)
         ? LeaseID.fromJSON(object.leaseId)
         : undefined,
@@ -298,8 +327,11 @@ export const Lease = {
   },
 };
 
+messageTypeRegistry.set(Lease.$type, Lease);
+
 function createBaseLeaseFilters(): LeaseFilters {
   return {
+    $type: "akash.market.v1beta1.LeaseFilters",
     owner: "",
     dseq: Long.UZERO,
     gseq: 0,
@@ -310,6 +342,8 @@ function createBaseLeaseFilters(): LeaseFilters {
 }
 
 export const LeaseFilters = {
+  $type: "akash.market.v1beta1.LeaseFilters" as const,
+
   encode(
     message: LeaseFilters,
     writer: _m0.Writer = _m0.Writer.create()
@@ -370,6 +404,7 @@ export const LeaseFilters = {
 
   fromJSON(object: any): LeaseFilters {
     return {
+      $type: LeaseFilters.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -408,11 +443,15 @@ export const LeaseFilters = {
   },
 };
 
+messageTypeRegistry.set(LeaseFilters.$type, LeaseFilters);
+
 function createBaseMsgCreateLease(): MsgCreateLease {
-  return { bidId: undefined };
+  return { $type: "akash.market.v1beta1.MsgCreateLease", bidId: undefined };
 }
 
 export const MsgCreateLease = {
+  $type: "akash.market.v1beta1.MsgCreateLease" as const,
+
   encode(
     message: MsgCreateLease,
     writer: _m0.Writer = _m0.Writer.create()
@@ -443,6 +482,7 @@ export const MsgCreateLease = {
 
   fromJSON(object: any): MsgCreateLease {
     return {
+      $type: MsgCreateLease.$type,
       bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
     };
   },
@@ -466,11 +506,15 @@ export const MsgCreateLease = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateLease.$type, MsgCreateLease);
+
 function createBaseMsgCreateLeaseResponse(): MsgCreateLeaseResponse {
-  return {};
+  return { $type: "akash.market.v1beta1.MsgCreateLeaseResponse" };
 }
 
 export const MsgCreateLeaseResponse = {
+  $type: "akash.market.v1beta1.MsgCreateLeaseResponse" as const,
+
   encode(
     _: MsgCreateLeaseResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -497,7 +541,9 @@ export const MsgCreateLeaseResponse = {
   },
 
   fromJSON(_: any): MsgCreateLeaseResponse {
-    return {};
+    return {
+      $type: MsgCreateLeaseResponse.$type,
+    };
   },
 
   toJSON(_: MsgCreateLeaseResponse): unknown {
@@ -513,11 +559,15 @@ export const MsgCreateLeaseResponse = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateLeaseResponse.$type, MsgCreateLeaseResponse);
+
 function createBaseMsgWithdrawLease(): MsgWithdrawLease {
-  return { bidId: undefined };
+  return { $type: "akash.market.v1beta1.MsgWithdrawLease", bidId: undefined };
 }
 
 export const MsgWithdrawLease = {
+  $type: "akash.market.v1beta1.MsgWithdrawLease" as const,
+
   encode(
     message: MsgWithdrawLease,
     writer: _m0.Writer = _m0.Writer.create()
@@ -548,6 +598,7 @@ export const MsgWithdrawLease = {
 
   fromJSON(object: any): MsgWithdrawLease {
     return {
+      $type: MsgWithdrawLease.$type,
       bidId: isSet(object.bidId) ? LeaseID.fromJSON(object.bidId) : undefined,
     };
   },
@@ -571,11 +622,15 @@ export const MsgWithdrawLease = {
   },
 };
 
+messageTypeRegistry.set(MsgWithdrawLease.$type, MsgWithdrawLease);
+
 function createBaseMsgWithdrawLeaseResponse(): MsgWithdrawLeaseResponse {
-  return {};
+  return { $type: "akash.market.v1beta1.MsgWithdrawLeaseResponse" };
 }
 
 export const MsgWithdrawLeaseResponse = {
+  $type: "akash.market.v1beta1.MsgWithdrawLeaseResponse" as const,
+
   encode(
     _: MsgWithdrawLeaseResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -602,7 +657,9 @@ export const MsgWithdrawLeaseResponse = {
   },
 
   fromJSON(_: any): MsgWithdrawLeaseResponse {
-    return {};
+    return {
+      $type: MsgWithdrawLeaseResponse.$type,
+    };
   },
 
   toJSON(_: MsgWithdrawLeaseResponse): unknown {
@@ -618,11 +675,18 @@ export const MsgWithdrawLeaseResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgWithdrawLeaseResponse.$type,
+  MsgWithdrawLeaseResponse
+);
+
 function createBaseMsgCloseLease(): MsgCloseLease {
-  return { leaseId: undefined };
+  return { $type: "akash.market.v1beta1.MsgCloseLease", leaseId: undefined };
 }
 
 export const MsgCloseLease = {
+  $type: "akash.market.v1beta1.MsgCloseLease" as const,
+
   encode(
     message: MsgCloseLease,
     writer: _m0.Writer = _m0.Writer.create()
@@ -653,6 +717,7 @@ export const MsgCloseLease = {
 
   fromJSON(object: any): MsgCloseLease {
     return {
+      $type: MsgCloseLease.$type,
       leaseId: isSet(object.leaseId)
         ? LeaseID.fromJSON(object.leaseId)
         : undefined,
@@ -680,11 +745,15 @@ export const MsgCloseLease = {
   },
 };
 
+messageTypeRegistry.set(MsgCloseLease.$type, MsgCloseLease);
+
 function createBaseMsgCloseLeaseResponse(): MsgCloseLeaseResponse {
-  return {};
+  return { $type: "akash.market.v1beta1.MsgCloseLeaseResponse" };
 }
 
 export const MsgCloseLeaseResponse = {
+  $type: "akash.market.v1beta1.MsgCloseLeaseResponse" as const,
+
   encode(
     _: MsgCloseLeaseResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -711,7 +780,9 @@ export const MsgCloseLeaseResponse = {
   },
 
   fromJSON(_: any): MsgCloseLeaseResponse {
-    return {};
+    return {
+      $type: MsgCloseLeaseResponse.$type,
+    };
   },
 
   toJSON(_: MsgCloseLeaseResponse): unknown {
@@ -726,6 +797,8 @@ export const MsgCloseLeaseResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(MsgCloseLeaseResponse.$type, MsgCloseLeaseResponse);
 
 type Builtin =
   | Date
@@ -745,14 +818,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/order.ts
+++ b/src/protobuf/akash/market/v1beta1/order.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { GroupSpec } from "../../../akash/deployment/v1beta1/group";
@@ -7,6 +8,7 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** OrderID stores owner and all other seq numbers */
 export interface OrderID {
+  $type: "akash.market.v1beta1.OrderID";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -15,6 +17,7 @@ export interface OrderID {
 
 /** Order stores orderID, state of order and other details */
 export interface Order {
+  $type: "akash.market.v1beta1.Order";
   orderId?: OrderID;
   state: Order_State;
   spec?: GroupSpec;
@@ -72,6 +75,7 @@ export function order_StateToJSON(object: Order_State): string {
 
 /** OrderFilters defines flags for order list filter */
 export interface OrderFilters {
+  $type: "akash.market.v1beta1.OrderFilters";
   owner: string;
   dseq: Long;
   gseq: number;
@@ -80,10 +84,18 @@ export interface OrderFilters {
 }
 
 function createBaseOrderID(): OrderID {
-  return { owner: "", dseq: Long.UZERO, gseq: 0, oseq: 0 };
+  return {
+    $type: "akash.market.v1beta1.OrderID",
+    owner: "",
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+  };
 }
 
 export const OrderID = {
+  $type: "akash.market.v1beta1.OrderID" as const,
+
   encode(
     message: OrderID,
     writer: _m0.Writer = _m0.Writer.create()
@@ -132,6 +144,7 @@ export const OrderID = {
 
   fromJSON(object: any): OrderID {
     return {
+      $type: OrderID.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -162,8 +175,11 @@ export const OrderID = {
   },
 };
 
+messageTypeRegistry.set(OrderID.$type, OrderID);
+
 function createBaseOrder(): Order {
   return {
+    $type: "akash.market.v1beta1.Order",
     orderId: undefined,
     state: 0,
     spec: undefined,
@@ -172,6 +188,8 @@ function createBaseOrder(): Order {
 }
 
 export const Order = {
+  $type: "akash.market.v1beta1.Order" as const,
+
   encode(message: Order, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.orderId !== undefined) {
       OrderID.encode(message.orderId, writer.uint32(10).fork()).ldelim();
@@ -217,6 +235,7 @@ export const Order = {
 
   fromJSON(object: any): Order {
     return {
+      $type: Order.$type,
       orderId: isSet(object.orderId)
         ? OrderID.fromJSON(object.orderId)
         : undefined,
@@ -262,11 +281,22 @@ export const Order = {
   },
 };
 
+messageTypeRegistry.set(Order.$type, Order);
+
 function createBaseOrderFilters(): OrderFilters {
-  return { owner: "", dseq: Long.UZERO, gseq: 0, oseq: 0, state: "" };
+  return {
+    $type: "akash.market.v1beta1.OrderFilters",
+    owner: "",
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    state: "",
+  };
 }
 
 export const OrderFilters = {
+  $type: "akash.market.v1beta1.OrderFilters" as const,
+
   encode(
     message: OrderFilters,
     writer: _m0.Writer = _m0.Writer.create()
@@ -321,6 +351,7 @@ export const OrderFilters = {
 
   fromJSON(object: any): OrderFilters {
     return {
+      $type: OrderFilters.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
       gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
@@ -356,6 +387,8 @@ export const OrderFilters = {
   },
 };
 
+messageTypeRegistry.set(OrderFilters.$type, OrderFilters);
+
 type Builtin =
   | Date
   | Function
@@ -374,14 +407,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/params.ts
+++ b/src/protobuf/akash/market/v1beta1/params.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Coin } from "../../../cosmos/base/v1beta1/coin";
@@ -7,15 +8,22 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** Params is the params for the x/market module */
 export interface Params {
+  $type: "akash.market.v1beta1.Params";
   bidMinDeposit?: Coin;
   orderMaxBids: number;
 }
 
 function createBaseParams(): Params {
-  return { bidMinDeposit: undefined, orderMaxBids: 0 };
+  return {
+    $type: "akash.market.v1beta1.Params",
+    bidMinDeposit: undefined,
+    orderMaxBids: 0,
+  };
 }
 
 export const Params = {
+  $type: "akash.market.v1beta1.Params" as const,
+
   encode(
     message: Params,
     writer: _m0.Writer = _m0.Writer.create()
@@ -52,6 +60,7 @@ export const Params = {
 
   fromJSON(object: any): Params {
     return {
+      $type: Params.$type,
       bidMinDeposit: isSet(object.bidMinDeposit)
         ? Coin.fromJSON(object.bidMinDeposit)
         : undefined,
@@ -83,6 +92,8 @@ export const Params = {
   },
 };
 
+messageTypeRegistry.set(Params.$type, Params);
+
 type Builtin =
   | Date
   | Function
@@ -101,14 +112,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/market/v1beta1/query.ts
+++ b/src/protobuf/akash/market/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -22,77 +23,95 @@ export const protobufPackage = "akash.market.v1beta1";
 
 /** QueryOrdersRequest is request type for the Query/Orders RPC method */
 export interface QueryOrdersRequest {
+  $type: "akash.market.v1beta1.QueryOrdersRequest";
   filters?: OrderFilters;
   pagination?: PageRequest;
 }
 
 /** QueryOrdersResponse is response type for the Query/Orders RPC method */
 export interface QueryOrdersResponse {
+  $type: "akash.market.v1beta1.QueryOrdersResponse";
   orders: Order[];
   pagination?: PageResponse;
 }
 
 /** QueryOrderRequest is request type for the Query/Order RPC method */
 export interface QueryOrderRequest {
+  $type: "akash.market.v1beta1.QueryOrderRequest";
   id?: OrderID;
 }
 
 /** QueryOrderResponse is response type for the Query/Order RPC method */
 export interface QueryOrderResponse {
+  $type: "akash.market.v1beta1.QueryOrderResponse";
   order?: Order;
 }
 
 /** QueryBidsRequest is request type for the Query/Bids RPC method */
 export interface QueryBidsRequest {
+  $type: "akash.market.v1beta1.QueryBidsRequest";
   filters?: BidFilters;
   pagination?: PageRequest;
 }
 
 /** QueryBidsResponse is response type for the Query/Bids RPC method */
 export interface QueryBidsResponse {
+  $type: "akash.market.v1beta1.QueryBidsResponse";
   bids: QueryBidResponse[];
   pagination?: PageResponse;
 }
 
 /** QueryBidRequest is request type for the Query/Bid RPC method */
 export interface QueryBidRequest {
+  $type: "akash.market.v1beta1.QueryBidRequest";
   id?: BidID;
 }
 
 /** QueryBidResponse is response type for the Query/Bid RPC method */
 export interface QueryBidResponse {
+  $type: "akash.market.v1beta1.QueryBidResponse";
   bid?: Bid;
   escrowAccount?: Account;
 }
 
 /** QueryLeasesRequest is request type for the Query/Leases RPC method */
 export interface QueryLeasesRequest {
+  $type: "akash.market.v1beta1.QueryLeasesRequest";
   filters?: LeaseFilters;
   pagination?: PageRequest;
 }
 
 /** QueryLeasesResponse is response type for the Query/Leases RPC method */
 export interface QueryLeasesResponse {
+  $type: "akash.market.v1beta1.QueryLeasesResponse";
   leases: QueryLeaseResponse[];
   pagination?: PageResponse;
 }
 
 /** QueryLeaseRequest is request type for the Query/Lease RPC method */
 export interface QueryLeaseRequest {
+  $type: "akash.market.v1beta1.QueryLeaseRequest";
   id?: LeaseID;
 }
 
 /** QueryLeaseResponse is response type for the Query/Lease RPC method */
 export interface QueryLeaseResponse {
+  $type: "akash.market.v1beta1.QueryLeaseResponse";
   lease?: Lease;
   escrowPayment?: Payment;
 }
 
 function createBaseQueryOrdersRequest(): QueryOrdersRequest {
-  return { filters: undefined, pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryOrdersRequest",
+    filters: undefined,
+    pagination: undefined,
+  };
 }
 
 export const QueryOrdersRequest = {
+  $type: "akash.market.v1beta1.QueryOrdersRequest" as const,
+
   encode(
     message: QueryOrdersRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -129,6 +148,7 @@ export const QueryOrdersRequest = {
 
   fromJSON(object: any): QueryOrdersRequest {
     return {
+      $type: QueryOrdersRequest.$type,
       filters: isSet(object.filters)
         ? OrderFilters.fromJSON(object.filters)
         : undefined,
@@ -167,11 +187,19 @@ export const QueryOrdersRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryOrdersRequest.$type, QueryOrdersRequest);
+
 function createBaseQueryOrdersResponse(): QueryOrdersResponse {
-  return { orders: [], pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryOrdersResponse",
+    orders: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryOrdersResponse = {
+  $type: "akash.market.v1beta1.QueryOrdersResponse" as const,
+
   encode(
     message: QueryOrdersResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -211,6 +239,7 @@ export const QueryOrdersResponse = {
 
   fromJSON(object: any): QueryOrdersResponse {
     return {
+      $type: QueryOrdersResponse.$type,
       orders: Array.isArray(object?.orders)
         ? object.orders.map((e: any) => Order.fromJSON(e))
         : [],
@@ -247,11 +276,15 @@ export const QueryOrdersResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryOrdersResponse.$type, QueryOrdersResponse);
+
 function createBaseQueryOrderRequest(): QueryOrderRequest {
-  return { id: undefined };
+  return { $type: "akash.market.v1beta1.QueryOrderRequest", id: undefined };
 }
 
 export const QueryOrderRequest = {
+  $type: "akash.market.v1beta1.QueryOrderRequest" as const,
+
   encode(
     message: QueryOrderRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -282,6 +315,7 @@ export const QueryOrderRequest = {
 
   fromJSON(object: any): QueryOrderRequest {
     return {
+      $type: QueryOrderRequest.$type,
       id: isSet(object.id) ? OrderID.fromJSON(object.id) : undefined,
     };
   },
@@ -305,11 +339,15 @@ export const QueryOrderRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryOrderRequest.$type, QueryOrderRequest);
+
 function createBaseQueryOrderResponse(): QueryOrderResponse {
-  return { order: undefined };
+  return { $type: "akash.market.v1beta1.QueryOrderResponse", order: undefined };
 }
 
 export const QueryOrderResponse = {
+  $type: "akash.market.v1beta1.QueryOrderResponse" as const,
+
   encode(
     message: QueryOrderResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -340,6 +378,7 @@ export const QueryOrderResponse = {
 
   fromJSON(object: any): QueryOrderResponse {
     return {
+      $type: QueryOrderResponse.$type,
       order: isSet(object.order) ? Order.fromJSON(object.order) : undefined,
     };
   },
@@ -363,11 +402,19 @@ export const QueryOrderResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryOrderResponse.$type, QueryOrderResponse);
+
 function createBaseQueryBidsRequest(): QueryBidsRequest {
-  return { filters: undefined, pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryBidsRequest",
+    filters: undefined,
+    pagination: undefined,
+  };
 }
 
 export const QueryBidsRequest = {
+  $type: "akash.market.v1beta1.QueryBidsRequest" as const,
+
   encode(
     message: QueryBidsRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -404,6 +451,7 @@ export const QueryBidsRequest = {
 
   fromJSON(object: any): QueryBidsRequest {
     return {
+      $type: QueryBidsRequest.$type,
       filters: isSet(object.filters)
         ? BidFilters.fromJSON(object.filters)
         : undefined,
@@ -442,11 +490,19 @@ export const QueryBidsRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryBidsRequest.$type, QueryBidsRequest);
+
 function createBaseQueryBidsResponse(): QueryBidsResponse {
-  return { bids: [], pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryBidsResponse",
+    bids: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryBidsResponse = {
+  $type: "akash.market.v1beta1.QueryBidsResponse" as const,
+
   encode(
     message: QueryBidsResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -486,6 +542,7 @@ export const QueryBidsResponse = {
 
   fromJSON(object: any): QueryBidsResponse {
     return {
+      $type: QueryBidsResponse.$type,
       bids: Array.isArray(object?.bids)
         ? object.bids.map((e: any) => QueryBidResponse.fromJSON(e))
         : [],
@@ -525,11 +582,15 @@ export const QueryBidsResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryBidsResponse.$type, QueryBidsResponse);
+
 function createBaseQueryBidRequest(): QueryBidRequest {
-  return { id: undefined };
+  return { $type: "akash.market.v1beta1.QueryBidRequest", id: undefined };
 }
 
 export const QueryBidRequest = {
+  $type: "akash.market.v1beta1.QueryBidRequest" as const,
+
   encode(
     message: QueryBidRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -560,6 +621,7 @@ export const QueryBidRequest = {
 
   fromJSON(object: any): QueryBidRequest {
     return {
+      $type: QueryBidRequest.$type,
       id: isSet(object.id) ? BidID.fromJSON(object.id) : undefined,
     };
   },
@@ -583,11 +645,19 @@ export const QueryBidRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryBidRequest.$type, QueryBidRequest);
+
 function createBaseQueryBidResponse(): QueryBidResponse {
-  return { bid: undefined, escrowAccount: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryBidResponse",
+    bid: undefined,
+    escrowAccount: undefined,
+  };
 }
 
 export const QueryBidResponse = {
+  $type: "akash.market.v1beta1.QueryBidResponse" as const,
+
   encode(
     message: QueryBidResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -624,6 +694,7 @@ export const QueryBidResponse = {
 
   fromJSON(object: any): QueryBidResponse {
     return {
+      $type: QueryBidResponse.$type,
       bid: isSet(object.bid) ? Bid.fromJSON(object.bid) : undefined,
       escrowAccount: isSet(object.escrowAccount)
         ? Account.fromJSON(object.escrowAccount)
@@ -658,11 +729,19 @@ export const QueryBidResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryBidResponse.$type, QueryBidResponse);
+
 function createBaseQueryLeasesRequest(): QueryLeasesRequest {
-  return { filters: undefined, pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryLeasesRequest",
+    filters: undefined,
+    pagination: undefined,
+  };
 }
 
 export const QueryLeasesRequest = {
+  $type: "akash.market.v1beta1.QueryLeasesRequest" as const,
+
   encode(
     message: QueryLeasesRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -699,6 +778,7 @@ export const QueryLeasesRequest = {
 
   fromJSON(object: any): QueryLeasesRequest {
     return {
+      $type: QueryLeasesRequest.$type,
       filters: isSet(object.filters)
         ? LeaseFilters.fromJSON(object.filters)
         : undefined,
@@ -737,11 +817,19 @@ export const QueryLeasesRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryLeasesRequest.$type, QueryLeasesRequest);
+
 function createBaseQueryLeasesResponse(): QueryLeasesResponse {
-  return { leases: [], pagination: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryLeasesResponse",
+    leases: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryLeasesResponse = {
+  $type: "akash.market.v1beta1.QueryLeasesResponse" as const,
+
   encode(
     message: QueryLeasesResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -783,6 +871,7 @@ export const QueryLeasesResponse = {
 
   fromJSON(object: any): QueryLeasesResponse {
     return {
+      $type: QueryLeasesResponse.$type,
       leases: Array.isArray(object?.leases)
         ? object.leases.map((e: any) => QueryLeaseResponse.fromJSON(e))
         : [],
@@ -822,11 +911,15 @@ export const QueryLeasesResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryLeasesResponse.$type, QueryLeasesResponse);
+
 function createBaseQueryLeaseRequest(): QueryLeaseRequest {
-  return { id: undefined };
+  return { $type: "akash.market.v1beta1.QueryLeaseRequest", id: undefined };
 }
 
 export const QueryLeaseRequest = {
+  $type: "akash.market.v1beta1.QueryLeaseRequest" as const,
+
   encode(
     message: QueryLeaseRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -857,6 +950,7 @@ export const QueryLeaseRequest = {
 
   fromJSON(object: any): QueryLeaseRequest {
     return {
+      $type: QueryLeaseRequest.$type,
       id: isSet(object.id) ? LeaseID.fromJSON(object.id) : undefined,
     };
   },
@@ -880,11 +974,19 @@ export const QueryLeaseRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryLeaseRequest.$type, QueryLeaseRequest);
+
 function createBaseQueryLeaseResponse(): QueryLeaseResponse {
-  return { lease: undefined, escrowPayment: undefined };
+  return {
+    $type: "akash.market.v1beta1.QueryLeaseResponse",
+    lease: undefined,
+    escrowPayment: undefined,
+  };
 }
 
 export const QueryLeaseResponse = {
+  $type: "akash.market.v1beta1.QueryLeaseResponse" as const,
+
   encode(
     message: QueryLeaseResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -921,6 +1023,7 @@ export const QueryLeaseResponse = {
 
   fromJSON(object: any): QueryLeaseResponse {
     return {
+      $type: QueryLeaseResponse.$type,
       lease: isSet(object.lease) ? Lease.fromJSON(object.lease) : undefined,
       escrowPayment: isSet(object.escrowPayment)
         ? Payment.fromJSON(object.escrowPayment)
@@ -954,6 +1057,8 @@ export const QueryLeaseResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(QueryLeaseResponse.$type, QueryLeaseResponse);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -1077,14 +1182,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/provider/v1beta1/genesis.ts
+++ b/src/protobuf/akash/provider/v1beta1/genesis.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Provider } from "../../../akash/provider/v1beta1/provider";
@@ -7,14 +8,17 @@ export const protobufPackage = "akash.provider.v1beta1";
 
 /** GenesisState defines the basic genesis state used by provider module */
 export interface GenesisState {
+  $type: "akash.provider.v1beta1.GenesisState";
   providers: Provider[];
 }
 
 function createBaseGenesisState(): GenesisState {
-  return { providers: [] };
+  return { $type: "akash.provider.v1beta1.GenesisState", providers: [] };
 }
 
 export const GenesisState = {
+  $type: "akash.provider.v1beta1.GenesisState" as const,
+
   encode(
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
@@ -45,6 +49,7 @@ export const GenesisState = {
 
   fromJSON(object: any): GenesisState {
     return {
+      $type: GenesisState.$type,
       providers: Array.isArray(object?.providers)
         ? object.providers.map((e: any) => Provider.fromJSON(e))
         : [],
@@ -73,6 +78,8 @@ export const GenesisState = {
   },
 };
 
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
 type Builtin =
   | Date
   | Function
@@ -91,14 +98,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/provider/v1beta1/provider.ts
+++ b/src/protobuf/akash/provider/v1beta1/provider.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import { Attribute } from "../../../akash/base/v1beta1/attribute";
@@ -7,12 +8,14 @@ export const protobufPackage = "akash.provider.v1beta1";
 
 /** ProviderInfo */
 export interface ProviderInfo {
+  $type: "akash.provider.v1beta1.ProviderInfo";
   email: string;
   website: string;
 }
 
 /** MsgCreateProvider defines an SDK message for creating a provider */
 export interface MsgCreateProvider {
+  $type: "akash.provider.v1beta1.MsgCreateProvider";
   owner: string;
   hostUri: string;
   attributes: Attribute[];
@@ -20,10 +23,13 @@ export interface MsgCreateProvider {
 }
 
 /** MsgCreateProviderResponse defines the Msg/CreateProvider response type. */
-export interface MsgCreateProviderResponse {}
+export interface MsgCreateProviderResponse {
+  $type: "akash.provider.v1beta1.MsgCreateProviderResponse";
+}
 
 /** MsgUpdateProvider defines an SDK message for updating a provider */
 export interface MsgUpdateProvider {
+  $type: "akash.provider.v1beta1.MsgUpdateProvider";
   owner: string;
   hostUri: string;
   attributes: Attribute[];
@@ -31,18 +37,24 @@ export interface MsgUpdateProvider {
 }
 
 /** MsgUpdateProviderResponse defines the Msg/UpdateProvider response type. */
-export interface MsgUpdateProviderResponse {}
+export interface MsgUpdateProviderResponse {
+  $type: "akash.provider.v1beta1.MsgUpdateProviderResponse";
+}
 
 /** MsgDeleteProvider defines an SDK message for deleting a provider */
 export interface MsgDeleteProvider {
+  $type: "akash.provider.v1beta1.MsgDeleteProvider";
   owner: string;
 }
 
 /** MsgDeleteProviderResponse defines the Msg/DeleteProvider response type. */
-export interface MsgDeleteProviderResponse {}
+export interface MsgDeleteProviderResponse {
+  $type: "akash.provider.v1beta1.MsgDeleteProviderResponse";
+}
 
 /** Provider stores owner and host details */
 export interface Provider {
+  $type: "akash.provider.v1beta1.Provider";
   owner: string;
   hostUri: string;
   attributes: Attribute[];
@@ -50,10 +62,16 @@ export interface Provider {
 }
 
 function createBaseProviderInfo(): ProviderInfo {
-  return { email: "", website: "" };
+  return {
+    $type: "akash.provider.v1beta1.ProviderInfo",
+    email: "",
+    website: "",
+  };
 }
 
 export const ProviderInfo = {
+  $type: "akash.provider.v1beta1.ProviderInfo" as const,
+
   encode(
     message: ProviderInfo,
     writer: _m0.Writer = _m0.Writer.create()
@@ -90,6 +108,7 @@ export const ProviderInfo = {
 
   fromJSON(object: any): ProviderInfo {
     return {
+      $type: ProviderInfo.$type,
       email: isSet(object.email) ? String(object.email) : "",
       website: isSet(object.website) ? String(object.website) : "",
     };
@@ -112,11 +131,21 @@ export const ProviderInfo = {
   },
 };
 
+messageTypeRegistry.set(ProviderInfo.$type, ProviderInfo);
+
 function createBaseMsgCreateProvider(): MsgCreateProvider {
-  return { owner: "", hostUri: "", attributes: [], info: undefined };
+  return {
+    $type: "akash.provider.v1beta1.MsgCreateProvider",
+    owner: "",
+    hostUri: "",
+    attributes: [],
+    info: undefined,
+  };
 }
 
 export const MsgCreateProvider = {
+  $type: "akash.provider.v1beta1.MsgCreateProvider" as const,
+
   encode(
     message: MsgCreateProvider,
     writer: _m0.Writer = _m0.Writer.create()
@@ -165,6 +194,7 @@ export const MsgCreateProvider = {
 
   fromJSON(object: any): MsgCreateProvider {
     return {
+      $type: MsgCreateProvider.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       hostUri: isSet(object.hostUri) ? String(object.hostUri) : "",
       attributes: Array.isArray(object?.attributes)
@@ -206,11 +236,15 @@ export const MsgCreateProvider = {
   },
 };
 
+messageTypeRegistry.set(MsgCreateProvider.$type, MsgCreateProvider);
+
 function createBaseMsgCreateProviderResponse(): MsgCreateProviderResponse {
-  return {};
+  return { $type: "akash.provider.v1beta1.MsgCreateProviderResponse" };
 }
 
 export const MsgCreateProviderResponse = {
+  $type: "akash.provider.v1beta1.MsgCreateProviderResponse" as const,
+
   encode(
     _: MsgCreateProviderResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -237,7 +271,9 @@ export const MsgCreateProviderResponse = {
   },
 
   fromJSON(_: any): MsgCreateProviderResponse {
-    return {};
+    return {
+      $type: MsgCreateProviderResponse.$type,
+    };
   },
 
   toJSON(_: MsgCreateProviderResponse): unknown {
@@ -253,11 +289,24 @@ export const MsgCreateProviderResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgCreateProviderResponse.$type,
+  MsgCreateProviderResponse
+);
+
 function createBaseMsgUpdateProvider(): MsgUpdateProvider {
-  return { owner: "", hostUri: "", attributes: [], info: undefined };
+  return {
+    $type: "akash.provider.v1beta1.MsgUpdateProvider",
+    owner: "",
+    hostUri: "",
+    attributes: [],
+    info: undefined,
+  };
 }
 
 export const MsgUpdateProvider = {
+  $type: "akash.provider.v1beta1.MsgUpdateProvider" as const,
+
   encode(
     message: MsgUpdateProvider,
     writer: _m0.Writer = _m0.Writer.create()
@@ -306,6 +355,7 @@ export const MsgUpdateProvider = {
 
   fromJSON(object: any): MsgUpdateProvider {
     return {
+      $type: MsgUpdateProvider.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       hostUri: isSet(object.hostUri) ? String(object.hostUri) : "",
       attributes: Array.isArray(object?.attributes)
@@ -347,11 +397,15 @@ export const MsgUpdateProvider = {
   },
 };
 
+messageTypeRegistry.set(MsgUpdateProvider.$type, MsgUpdateProvider);
+
 function createBaseMsgUpdateProviderResponse(): MsgUpdateProviderResponse {
-  return {};
+  return { $type: "akash.provider.v1beta1.MsgUpdateProviderResponse" };
 }
 
 export const MsgUpdateProviderResponse = {
+  $type: "akash.provider.v1beta1.MsgUpdateProviderResponse" as const,
+
   encode(
     _: MsgUpdateProviderResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -378,7 +432,9 @@ export const MsgUpdateProviderResponse = {
   },
 
   fromJSON(_: any): MsgUpdateProviderResponse {
-    return {};
+    return {
+      $type: MsgUpdateProviderResponse.$type,
+    };
   },
 
   toJSON(_: MsgUpdateProviderResponse): unknown {
@@ -394,11 +450,18 @@ export const MsgUpdateProviderResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgUpdateProviderResponse.$type,
+  MsgUpdateProviderResponse
+);
+
 function createBaseMsgDeleteProvider(): MsgDeleteProvider {
-  return { owner: "" };
+  return { $type: "akash.provider.v1beta1.MsgDeleteProvider", owner: "" };
 }
 
 export const MsgDeleteProvider = {
+  $type: "akash.provider.v1beta1.MsgDeleteProvider" as const,
+
   encode(
     message: MsgDeleteProvider,
     writer: _m0.Writer = _m0.Writer.create()
@@ -429,6 +492,7 @@ export const MsgDeleteProvider = {
 
   fromJSON(object: any): MsgDeleteProvider {
     return {
+      $type: MsgDeleteProvider.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
     };
   },
@@ -448,11 +512,15 @@ export const MsgDeleteProvider = {
   },
 };
 
+messageTypeRegistry.set(MsgDeleteProvider.$type, MsgDeleteProvider);
+
 function createBaseMsgDeleteProviderResponse(): MsgDeleteProviderResponse {
-  return {};
+  return { $type: "akash.provider.v1beta1.MsgDeleteProviderResponse" };
 }
 
 export const MsgDeleteProviderResponse = {
+  $type: "akash.provider.v1beta1.MsgDeleteProviderResponse" as const,
+
   encode(
     _: MsgDeleteProviderResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -479,7 +547,9 @@ export const MsgDeleteProviderResponse = {
   },
 
   fromJSON(_: any): MsgDeleteProviderResponse {
-    return {};
+    return {
+      $type: MsgDeleteProviderResponse.$type,
+    };
   },
 
   toJSON(_: MsgDeleteProviderResponse): unknown {
@@ -495,11 +565,24 @@ export const MsgDeleteProviderResponse = {
   },
 };
 
+messageTypeRegistry.set(
+  MsgDeleteProviderResponse.$type,
+  MsgDeleteProviderResponse
+);
+
 function createBaseProvider(): Provider {
-  return { owner: "", hostUri: "", attributes: [], info: undefined };
+  return {
+    $type: "akash.provider.v1beta1.Provider",
+    owner: "",
+    hostUri: "",
+    attributes: [],
+    info: undefined,
+  };
 }
 
 export const Provider = {
+  $type: "akash.provider.v1beta1.Provider" as const,
+
   encode(
     message: Provider,
     writer: _m0.Writer = _m0.Writer.create()
@@ -548,6 +631,7 @@ export const Provider = {
 
   fromJSON(object: any): Provider {
     return {
+      $type: Provider.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
       hostUri: isSet(object.hostUri) ? String(object.hostUri) : "",
       attributes: Array.isArray(object?.attributes)
@@ -586,6 +670,8 @@ export const Provider = {
     return message;
   },
 };
+
+messageTypeRegistry.set(Provider.$type, Provider);
 
 /** Msg defines the provider Msg service */
 export interface Msg {
@@ -680,14 +766,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/akash/provider/v1beta1/query.ts
+++ b/src/protobuf/akash/provider/v1beta1/query.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 import {
@@ -11,30 +12,39 @@ export const protobufPackage = "akash.provider.v1beta1";
 
 /** QueryProvidersRequest is request type for the Query/Providers RPC method */
 export interface QueryProvidersRequest {
+  $type: "akash.provider.v1beta1.QueryProvidersRequest";
   pagination?: PageRequest;
 }
 
 /** QueryProvidersResponse is response type for the Query/Providers RPC method */
 export interface QueryProvidersResponse {
+  $type: "akash.provider.v1beta1.QueryProvidersResponse";
   providers: Provider[];
   pagination?: PageResponse;
 }
 
 /** QueryProviderRequest is request type for the Query/Provider RPC method */
 export interface QueryProviderRequest {
+  $type: "akash.provider.v1beta1.QueryProviderRequest";
   owner: string;
 }
 
 /** QueryProviderResponse is response type for the Query/Provider RPC method */
 export interface QueryProviderResponse {
+  $type: "akash.provider.v1beta1.QueryProviderResponse";
   provider?: Provider;
 }
 
 function createBaseQueryProvidersRequest(): QueryProvidersRequest {
-  return { pagination: undefined };
+  return {
+    $type: "akash.provider.v1beta1.QueryProvidersRequest",
+    pagination: undefined,
+  };
 }
 
 export const QueryProvidersRequest = {
+  $type: "akash.provider.v1beta1.QueryProvidersRequest" as const,
+
   encode(
     message: QueryProvidersRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -68,6 +78,7 @@ export const QueryProvidersRequest = {
 
   fromJSON(object: any): QueryProvidersRequest {
     return {
+      $type: QueryProvidersRequest.$type,
       pagination: isSet(object.pagination)
         ? PageRequest.fromJSON(object.pagination)
         : undefined,
@@ -95,11 +106,19 @@ export const QueryProvidersRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryProvidersRequest.$type, QueryProvidersRequest);
+
 function createBaseQueryProvidersResponse(): QueryProvidersResponse {
-  return { providers: [], pagination: undefined };
+  return {
+    $type: "akash.provider.v1beta1.QueryProvidersResponse",
+    providers: [],
+    pagination: undefined,
+  };
 }
 
 export const QueryProvidersResponse = {
+  $type: "akash.provider.v1beta1.QueryProvidersResponse" as const,
+
   encode(
     message: QueryProvidersResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -142,6 +161,7 @@ export const QueryProvidersResponse = {
 
   fromJSON(object: any): QueryProvidersResponse {
     return {
+      $type: QueryProvidersResponse.$type,
       providers: Array.isArray(object?.providers)
         ? object.providers.map((e: any) => Provider.fromJSON(e))
         : [],
@@ -181,11 +201,15 @@ export const QueryProvidersResponse = {
   },
 };
 
+messageTypeRegistry.set(QueryProvidersResponse.$type, QueryProvidersResponse);
+
 function createBaseQueryProviderRequest(): QueryProviderRequest {
-  return { owner: "" };
+  return { $type: "akash.provider.v1beta1.QueryProviderRequest", owner: "" };
 }
 
 export const QueryProviderRequest = {
+  $type: "akash.provider.v1beta1.QueryProviderRequest" as const,
+
   encode(
     message: QueryProviderRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -219,6 +243,7 @@ export const QueryProviderRequest = {
 
   fromJSON(object: any): QueryProviderRequest {
     return {
+      $type: QueryProviderRequest.$type,
       owner: isSet(object.owner) ? String(object.owner) : "",
     };
   },
@@ -238,11 +263,18 @@ export const QueryProviderRequest = {
   },
 };
 
+messageTypeRegistry.set(QueryProviderRequest.$type, QueryProviderRequest);
+
 function createBaseQueryProviderResponse(): QueryProviderResponse {
-  return { provider: undefined };
+  return {
+    $type: "akash.provider.v1beta1.QueryProviderResponse",
+    provider: undefined,
+  };
 }
 
 export const QueryProviderResponse = {
+  $type: "akash.provider.v1beta1.QueryProviderResponse" as const,
+
   encode(
     message: QueryProviderResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -276,6 +308,7 @@ export const QueryProviderResponse = {
 
   fromJSON(object: any): QueryProviderResponse {
     return {
+      $type: QueryProviderResponse.$type,
       provider: isSet(object.provider)
         ? Provider.fromJSON(object.provider)
         : undefined,
@@ -302,6 +335,8 @@ export const QueryProviderResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(QueryProviderResponse.$type, QueryProviderResponse);
 
 /** Query defines the gRPC querier service */
 export interface Query {
@@ -369,14 +404,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/cosmos/base/query/v1beta1/pagination.ts
+++ b/src/protobuf/cosmos/base/query/v1beta1/pagination.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -14,6 +15,7 @@ export const protobufPackage = "cosmos.base.query.v1beta1";
  *  }
  */
 export interface PageRequest {
+  $type: "cosmos.base.query.v1beta1.PageRequest";
   /**
    * key is a value returned in PageResponse.next_key to begin
    * querying the next page most efficiently. Only one of offset or key
@@ -52,6 +54,7 @@ export interface PageRequest {
  *  }
  */
 export interface PageResponse {
+  $type: "cosmos.base.query.v1beta1.PageResponse";
   /**
    * next_key is the key to be passed to PageRequest.key to
    * query the next page most efficiently
@@ -66,6 +69,7 @@ export interface PageResponse {
 
 function createBasePageRequest(): PageRequest {
   return {
+    $type: "cosmos.base.query.v1beta1.PageRequest",
     key: new Uint8Array(),
     offset: Long.UZERO,
     limit: Long.UZERO,
@@ -75,6 +79,8 @@ function createBasePageRequest(): PageRequest {
 }
 
 export const PageRequest = {
+  $type: "cosmos.base.query.v1beta1.PageRequest" as const,
+
   encode(
     message: PageRequest,
     writer: _m0.Writer = _m0.Writer.create()
@@ -129,6 +135,7 @@ export const PageRequest = {
 
   fromJSON(object: any): PageRequest {
     return {
+      $type: PageRequest.$type,
       key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array(),
       offset: isSet(object.offset)
         ? Long.fromString(object.offset)
@@ -173,11 +180,19 @@ export const PageRequest = {
   },
 };
 
+messageTypeRegistry.set(PageRequest.$type, PageRequest);
+
 function createBasePageResponse(): PageResponse {
-  return { nextKey: new Uint8Array(), total: Long.UZERO };
+  return {
+    $type: "cosmos.base.query.v1beta1.PageResponse",
+    nextKey: new Uint8Array(),
+    total: Long.UZERO,
+  };
 }
 
 export const PageResponse = {
+  $type: "cosmos.base.query.v1beta1.PageResponse" as const,
+
   encode(
     message: PageResponse,
     writer: _m0.Writer = _m0.Writer.create()
@@ -214,6 +229,7 @@ export const PageResponse = {
 
   fromJSON(object: any): PageResponse {
     return {
+      $type: PageResponse.$type,
       nextKey: isSet(object.nextKey)
         ? bytesFromBase64(object.nextKey)
         : new Uint8Array(),
@@ -244,6 +260,8 @@ export const PageResponse = {
     return message;
   },
 };
+
+messageTypeRegistry.set(PageResponse.$type, PageResponse);
 
 declare var self: any | undefined;
 declare var window: any | undefined;
@@ -297,14 +315,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/cosmos/base/v1beta1/coin.ts
+++ b/src/protobuf/cosmos/base/v1beta1/coin.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -11,6 +12,7 @@ export const protobufPackage = "cosmos.base.v1beta1";
  * signatures required by gogoproto.
  */
 export interface Coin {
+  $type: "cosmos.base.v1beta1.Coin";
   denom: string;
   amount: string;
 }
@@ -22,25 +24,30 @@ export interface Coin {
  * signatures required by gogoproto.
  */
 export interface DecCoin {
+  $type: "cosmos.base.v1beta1.DecCoin";
   denom: string;
   amount: string;
 }
 
 /** IntProto defines a Protobuf wrapper around an Int object. */
 export interface IntProto {
+  $type: "cosmos.base.v1beta1.IntProto";
   int: string;
 }
 
 /** DecProto defines a Protobuf wrapper around a Dec object. */
 export interface DecProto {
+  $type: "cosmos.base.v1beta1.DecProto";
   dec: string;
 }
 
 function createBaseCoin(): Coin {
-  return { denom: "", amount: "" };
+  return { $type: "cosmos.base.v1beta1.Coin", denom: "", amount: "" };
 }
 
 export const Coin = {
+  $type: "cosmos.base.v1beta1.Coin" as const,
+
   encode(message: Coin, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.denom !== "") {
       writer.uint32(10).string(message.denom);
@@ -74,6 +81,7 @@ export const Coin = {
 
   fromJSON(object: any): Coin {
     return {
+      $type: Coin.$type,
       denom: isSet(object.denom) ? String(object.denom) : "",
       amount: isSet(object.amount) ? String(object.amount) : "",
     };
@@ -94,11 +102,15 @@ export const Coin = {
   },
 };
 
+messageTypeRegistry.set(Coin.$type, Coin);
+
 function createBaseDecCoin(): DecCoin {
-  return { denom: "", amount: "" };
+  return { $type: "cosmos.base.v1beta1.DecCoin", denom: "", amount: "" };
 }
 
 export const DecCoin = {
+  $type: "cosmos.base.v1beta1.DecCoin" as const,
+
   encode(
     message: DecCoin,
     writer: _m0.Writer = _m0.Writer.create()
@@ -135,6 +147,7 @@ export const DecCoin = {
 
   fromJSON(object: any): DecCoin {
     return {
+      $type: DecCoin.$type,
       denom: isSet(object.denom) ? String(object.denom) : "",
       amount: isSet(object.amount) ? String(object.amount) : "",
     };
@@ -155,11 +168,15 @@ export const DecCoin = {
   },
 };
 
+messageTypeRegistry.set(DecCoin.$type, DecCoin);
+
 function createBaseIntProto(): IntProto {
-  return { int: "" };
+  return { $type: "cosmos.base.v1beta1.IntProto", int: "" };
 }
 
 export const IntProto = {
+  $type: "cosmos.base.v1beta1.IntProto" as const,
+
   encode(
     message: IntProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -190,6 +207,7 @@ export const IntProto = {
 
   fromJSON(object: any): IntProto {
     return {
+      $type: IntProto.$type,
       int: isSet(object.int) ? String(object.int) : "",
     };
   },
@@ -207,11 +225,15 @@ export const IntProto = {
   },
 };
 
+messageTypeRegistry.set(IntProto.$type, IntProto);
+
 function createBaseDecProto(): DecProto {
-  return { dec: "" };
+  return { $type: "cosmos.base.v1beta1.DecProto", dec: "" };
 }
 
 export const DecProto = {
+  $type: "cosmos.base.v1beta1.DecProto" as const,
+
   encode(
     message: DecProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -242,6 +264,7 @@ export const DecProto = {
 
   fromJSON(object: any): DecProto {
     return {
+      $type: DecProto.$type,
       dec: isSet(object.dec) ? String(object.dec) : "",
     };
   },
@@ -258,6 +281,8 @@ export const DecProto = {
     return message;
   },
 };
+
+messageTypeRegistry.set(DecProto.$type, DecProto);
 
 type Builtin =
   | Date
@@ -277,14 +302,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/google/api/http.ts
+++ b/src/protobuf/google/api/http.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -10,6 +11,7 @@ export const protobufPackage = "google.api";
  * to one or more HTTP REST API methods.
  */
 export interface Http {
+  $type: "google.api.Http";
   /**
    * A list of HTTP configuration rules that apply to individual API methods.
    *
@@ -247,6 +249,7 @@ export interface Http {
  * repeated fields or map fields.
  */
 export interface HttpRule {
+  $type: "google.api.HttpRule";
   /**
    * Selects methods to which this rule applies.
    *
@@ -293,6 +296,7 @@ export interface HttpRule {
 
 /** A custom pattern is used for defining custom HTTP verb. */
 export interface CustomHttpPattern {
+  $type: "google.api.CustomHttpPattern";
   /** The name of this custom HTTP verb. */
   kind: string;
   /** The path matched by this custom verb. */
@@ -300,10 +304,16 @@ export interface CustomHttpPattern {
 }
 
 function createBaseHttp(): Http {
-  return { rules: [], fullyDecodeReservedExpansion: false };
+  return {
+    $type: "google.api.Http",
+    rules: [],
+    fullyDecodeReservedExpansion: false,
+  };
 }
 
 export const Http = {
+  $type: "google.api.Http" as const,
+
   encode(message: Http, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.rules) {
       HttpRule.encode(v!, writer.uint32(10).fork()).ldelim();
@@ -337,6 +347,7 @@ export const Http = {
 
   fromJSON(object: any): Http {
     return {
+      $type: Http.$type,
       rules: Array.isArray(object?.rules)
         ? object.rules.map((e: any) => HttpRule.fromJSON(e))
         : [],
@@ -369,8 +380,11 @@ export const Http = {
   },
 };
 
+messageTypeRegistry.set(Http.$type, Http);
+
 function createBaseHttpRule(): HttpRule {
   return {
+    $type: "google.api.HttpRule",
     selector: "",
     get: undefined,
     put: undefined,
@@ -385,6 +399,8 @@ function createBaseHttpRule(): HttpRule {
 }
 
 export const HttpRule = {
+  $type: "google.api.HttpRule" as const,
+
   encode(
     message: HttpRule,
     writer: _m0.Writer = _m0.Writer.create()
@@ -474,6 +490,7 @@ export const HttpRule = {
 
   fromJSON(object: any): HttpRule {
     return {
+      $type: HttpRule.$type,
       selector: isSet(object.selector) ? String(object.selector) : "",
       get: isSet(object.get) ? String(object.get) : undefined,
       put: isSet(object.put) ? String(object.put) : undefined,
@@ -538,11 +555,15 @@ export const HttpRule = {
   },
 };
 
+messageTypeRegistry.set(HttpRule.$type, HttpRule);
+
 function createBaseCustomHttpPattern(): CustomHttpPattern {
-  return { kind: "", path: "" };
+  return { $type: "google.api.CustomHttpPattern", kind: "", path: "" };
 }
 
 export const CustomHttpPattern = {
+  $type: "google.api.CustomHttpPattern" as const,
+
   encode(
     message: CustomHttpPattern,
     writer: _m0.Writer = _m0.Writer.create()
@@ -579,6 +600,7 @@ export const CustomHttpPattern = {
 
   fromJSON(object: any): CustomHttpPattern {
     return {
+      $type: CustomHttpPattern.$type,
       kind: isSet(object.kind) ? String(object.kind) : "",
       path: isSet(object.path) ? String(object.path) : "",
     };
@@ -601,6 +623,8 @@ export const CustomHttpPattern = {
   },
 };
 
+messageTypeRegistry.set(CustomHttpPattern.$type, CustomHttpPattern);
+
 type Builtin =
   | Date
   | Function
@@ -619,14 +643,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/google/protobuf/descriptor.ts
+++ b/src/protobuf/google/protobuf/descriptor.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { messageTypeRegistry } from "../../typeRegistry";
 import Long from "long";
 import _m0 from "protobufjs/minimal";
 
@@ -9,11 +10,13 @@ export const protobufPackage = "google.protobuf";
  * files it parses.
  */
 export interface FileDescriptorSet {
+  $type: "google.protobuf.FileDescriptorSet";
   file: FileDescriptorProto[];
 }
 
 /** Describes a complete .proto file. */
 export interface FileDescriptorProto {
+  $type: "google.protobuf.FileDescriptorProto";
   /** file name, relative to root of source tree */
   name: string;
   /** e.g. "foo", "foo.bar", etc. */
@@ -49,6 +52,7 @@ export interface FileDescriptorProto {
 
 /** Describes a message type. */
 export interface DescriptorProto {
+  $type: "google.protobuf.DescriptorProto";
   name: string;
   field: FieldDescriptorProto[];
   extension: FieldDescriptorProto[];
@@ -66,6 +70,7 @@ export interface DescriptorProto {
 }
 
 export interface DescriptorProto_ExtensionRange {
+  $type: "google.protobuf.DescriptorProto.ExtensionRange";
   /** Inclusive. */
   start: number;
   /** Exclusive. */
@@ -79,6 +84,7 @@ export interface DescriptorProto_ExtensionRange {
  * not overlap.
  */
 export interface DescriptorProto_ReservedRange {
+  $type: "google.protobuf.DescriptorProto.ReservedRange";
   /** Inclusive. */
   start: number;
   /** Exclusive. */
@@ -86,12 +92,14 @@ export interface DescriptorProto_ReservedRange {
 }
 
 export interface ExtensionRangeOptions {
+  $type: "google.protobuf.ExtensionRangeOptions";
   /** The parser stores options it doesn't recognize here. See above. */
   uninterpretedOption: UninterpretedOption[];
 }
 
 /** Describes a field within a message. */
 export interface FieldDescriptorProto {
+  $type: "google.protobuf.FieldDescriptorProto";
   name: string;
   number: number;
   label: FieldDescriptorProto_Label;
@@ -359,12 +367,14 @@ export function fieldDescriptorProto_LabelToJSON(
 
 /** Describes a oneof. */
 export interface OneofDescriptorProto {
+  $type: "google.protobuf.OneofDescriptorProto";
   name: string;
   options?: OneofOptions;
 }
 
 /** Describes an enum type. */
 export interface EnumDescriptorProto {
+  $type: "google.protobuf.EnumDescriptorProto";
   name: string;
   value: EnumValueDescriptorProto[];
   options?: EnumOptions;
@@ -390,6 +400,7 @@ export interface EnumDescriptorProto {
  * domain.
  */
 export interface EnumDescriptorProto_EnumReservedRange {
+  $type: "google.protobuf.EnumDescriptorProto.EnumReservedRange";
   /** Inclusive. */
   start: number;
   /** Inclusive. */
@@ -398,6 +409,7 @@ export interface EnumDescriptorProto_EnumReservedRange {
 
 /** Describes a value within an enum. */
 export interface EnumValueDescriptorProto {
+  $type: "google.protobuf.EnumValueDescriptorProto";
   name: string;
   number: number;
   options?: EnumValueOptions;
@@ -405,6 +417,7 @@ export interface EnumValueDescriptorProto {
 
 /** Describes a service. */
 export interface ServiceDescriptorProto {
+  $type: "google.protobuf.ServiceDescriptorProto";
   name: string;
   method: MethodDescriptorProto[];
   options?: ServiceOptions;
@@ -412,6 +425,7 @@ export interface ServiceDescriptorProto {
 
 /** Describes a method of a service. */
 export interface MethodDescriptorProto {
+  $type: "google.protobuf.MethodDescriptorProto";
   name: string;
   /**
    * Input and output type names.  These are resolved in the same way as
@@ -427,6 +441,7 @@ export interface MethodDescriptorProto {
 }
 
 export interface FileOptions {
+  $type: "google.protobuf.FileOptions";
   /**
    * Sets the Java package where classes generated from this .proto will be
    * placed.  By default, the proto package is used, but this is often
@@ -594,6 +609,7 @@ export function fileOptions_OptimizeModeToJSON(
 }
 
 export interface MessageOptions {
+  $type: "google.protobuf.MessageOptions";
   /**
    * Set true to use the old proto1 MessageSet wire format for extensions.
    * This is provided for backwards-compatibility with the MessageSet wire
@@ -657,6 +673,7 @@ export interface MessageOptions {
 }
 
 export interface FieldOptions {
+  $type: "google.protobuf.FieldOptions";
   /**
    * The ctype option instructs the C++ code generator to use a different
    * representation of the field than it normally would.  See the specific
@@ -811,11 +828,13 @@ export function fieldOptions_JSTypeToJSON(object: FieldOptions_JSType): string {
 }
 
 export interface OneofOptions {
+  $type: "google.protobuf.OneofOptions";
   /** The parser stores options it doesn't recognize here. See above. */
   uninterpretedOption: UninterpretedOption[];
 }
 
 export interface EnumOptions {
+  $type: "google.protobuf.EnumOptions";
   /**
    * Set this option to true to allow mapping different tag names to the same
    * value.
@@ -833,6 +852,7 @@ export interface EnumOptions {
 }
 
 export interface EnumValueOptions {
+  $type: "google.protobuf.EnumValueOptions";
   /**
    * Is this enum value deprecated?
    * Depending on the target platform, this can emit Deprecated annotations
@@ -845,6 +865,7 @@ export interface EnumValueOptions {
 }
 
 export interface ServiceOptions {
+  $type: "google.protobuf.ServiceOptions";
   /**
    * Is this service deprecated?
    * Depending on the target platform, this can emit Deprecated annotations
@@ -857,6 +878,7 @@ export interface ServiceOptions {
 }
 
 export interface MethodOptions {
+  $type: "google.protobuf.MethodOptions";
   /**
    * Is this method deprecated?
    * Depending on the target platform, this can emit Deprecated annotations
@@ -927,6 +949,7 @@ export function methodOptions_IdempotencyLevelToJSON(
  * in them.
  */
 export interface UninterpretedOption {
+  $type: "google.protobuf.UninterpretedOption";
   name: UninterpretedOption_NamePart[];
   /**
    * The value of the uninterpreted option, in whatever type the tokenizer
@@ -948,6 +971,7 @@ export interface UninterpretedOption {
  * "foo.(bar.baz).qux".
  */
 export interface UninterpretedOption_NamePart {
+  $type: "google.protobuf.UninterpretedOption.NamePart";
   namePart: string;
   isExtension: boolean;
 }
@@ -957,6 +981,7 @@ export interface UninterpretedOption_NamePart {
  * FileDescriptorProto was generated.
  */
 export interface SourceCodeInfo {
+  $type: "google.protobuf.SourceCodeInfo";
   /**
    * A Location identifies a piece of source code in a .proto file which
    * corresponds to a particular definition.  This information is intended
@@ -1006,6 +1031,7 @@ export interface SourceCodeInfo {
 }
 
 export interface SourceCodeInfo_Location {
+  $type: "google.protobuf.SourceCodeInfo.Location";
   /**
    * Identifies which part of the FileDescriptorProto was defined at this
    * location.
@@ -1100,6 +1126,7 @@ export interface SourceCodeInfo_Location {
  * source file, but may contain references to different source .proto files.
  */
 export interface GeneratedCodeInfo {
+  $type: "google.protobuf.GeneratedCodeInfo";
   /**
    * An Annotation connects some span of text in generated code to an element
    * of its generating .proto file.
@@ -1108,6 +1135,7 @@ export interface GeneratedCodeInfo {
 }
 
 export interface GeneratedCodeInfo_Annotation {
+  $type: "google.protobuf.GeneratedCodeInfo.Annotation";
   /**
    * Identifies the element in the original source .proto file. This field
    * is formatted the same as SourceCodeInfo.Location.path.
@@ -1129,10 +1157,12 @@ export interface GeneratedCodeInfo_Annotation {
 }
 
 function createBaseFileDescriptorSet(): FileDescriptorSet {
-  return { file: [] };
+  return { $type: "google.protobuf.FileDescriptorSet", file: [] };
 }
 
 export const FileDescriptorSet = {
+  $type: "google.protobuf.FileDescriptorSet" as const,
+
   encode(
     message: FileDescriptorSet,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1165,6 +1195,7 @@ export const FileDescriptorSet = {
 
   fromJSON(object: any): FileDescriptorSet {
     return {
+      $type: FileDescriptorSet.$type,
       file: Array.isArray(object?.file)
         ? object.file.map((e: any) => FileDescriptorProto.fromJSON(e))
         : [],
@@ -1193,8 +1224,11 @@ export const FileDescriptorSet = {
   },
 };
 
+messageTypeRegistry.set(FileDescriptorSet.$type, FileDescriptorSet);
+
 function createBaseFileDescriptorProto(): FileDescriptorProto {
   return {
+    $type: "google.protobuf.FileDescriptorProto",
     name: "",
     package: "",
     dependency: [],
@@ -1211,6 +1245,8 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
 }
 
 export const FileDescriptorProto = {
+  $type: "google.protobuf.FileDescriptorProto" as const,
+
   encode(
     message: FileDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1339,6 +1375,7 @@ export const FileDescriptorProto = {
 
   fromJSON(object: any): FileDescriptorProto {
     return {
+      $type: FileDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       package: isSet(object.package) ? String(object.package) : "",
       dependency: Array.isArray(object?.dependency)
@@ -1461,8 +1498,11 @@ export const FileDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(FileDescriptorProto.$type, FileDescriptorProto);
+
 function createBaseDescriptorProto(): DescriptorProto {
   return {
+    $type: "google.protobuf.DescriptorProto",
     name: "",
     field: [],
     extension: [],
@@ -1477,6 +1517,8 @@ function createBaseDescriptorProto(): DescriptorProto {
 }
 
 export const DescriptorProto = {
+  $type: "google.protobuf.DescriptorProto" as const,
+
   encode(
     message: DescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1581,6 +1623,7 @@ export const DescriptorProto = {
 
   fromJSON(object: any): DescriptorProto {
     return {
+      $type: DescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       field: Array.isArray(object?.field)
         ? object.field.map((e: any) => FieldDescriptorProto.fromJSON(e))
@@ -1712,11 +1755,20 @@ export const DescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(DescriptorProto.$type, DescriptorProto);
+
 function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRange {
-  return { start: 0, end: 0, options: undefined };
+  return {
+    $type: "google.protobuf.DescriptorProto.ExtensionRange",
+    start: 0,
+    end: 0,
+    options: undefined,
+  };
 }
 
 export const DescriptorProto_ExtensionRange = {
+  $type: "google.protobuf.DescriptorProto.ExtensionRange" as const,
+
   encode(
     message: DescriptorProto_ExtensionRange,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1768,6 +1820,7 @@ export const DescriptorProto_ExtensionRange = {
 
   fromJSON(object: any): DescriptorProto_ExtensionRange {
     return {
+      $type: DescriptorProto_ExtensionRange.$type,
       start: isSet(object.start) ? Number(object.start) : 0,
       end: isSet(object.end) ? Number(object.end) : 0,
       options: isSet(object.options)
@@ -1801,11 +1854,22 @@ export const DescriptorProto_ExtensionRange = {
   },
 };
 
+messageTypeRegistry.set(
+  DescriptorProto_ExtensionRange.$type,
+  DescriptorProto_ExtensionRange
+);
+
 function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRange {
-  return { start: 0, end: 0 };
+  return {
+    $type: "google.protobuf.DescriptorProto.ReservedRange",
+    start: 0,
+    end: 0,
+  };
 }
 
 export const DescriptorProto_ReservedRange = {
+  $type: "google.protobuf.DescriptorProto.ReservedRange" as const,
+
   encode(
     message: DescriptorProto_ReservedRange,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1845,6 +1909,7 @@ export const DescriptorProto_ReservedRange = {
 
   fromJSON(object: any): DescriptorProto_ReservedRange {
     return {
+      $type: DescriptorProto_ReservedRange.$type,
       start: isSet(object.start) ? Number(object.start) : 0,
       end: isSet(object.end) ? Number(object.end) : 0,
     };
@@ -1867,11 +1932,21 @@ export const DescriptorProto_ReservedRange = {
   },
 };
 
+messageTypeRegistry.set(
+  DescriptorProto_ReservedRange.$type,
+  DescriptorProto_ReservedRange
+);
+
 function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
-  return { uninterpretedOption: [] };
+  return {
+    $type: "google.protobuf.ExtensionRangeOptions",
+    uninterpretedOption: [],
+  };
 }
 
 export const ExtensionRangeOptions = {
+  $type: "google.protobuf.ExtensionRangeOptions" as const,
+
   encode(
     message: ExtensionRangeOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -1907,6 +1982,7 @@ export const ExtensionRangeOptions = {
 
   fromJSON(object: any): ExtensionRangeOptions {
     return {
+      $type: ExtensionRangeOptions.$type,
       uninterpretedOption: Array.isArray(object?.uninterpretedOption)
         ? object.uninterpretedOption.map((e: any) =>
             UninterpretedOption.fromJSON(e)
@@ -1939,8 +2015,11 @@ export const ExtensionRangeOptions = {
   },
 };
 
+messageTypeRegistry.set(ExtensionRangeOptions.$type, ExtensionRangeOptions);
+
 function createBaseFieldDescriptorProto(): FieldDescriptorProto {
   return {
+    $type: "google.protobuf.FieldDescriptorProto",
     name: "",
     number: 0,
     label: 1,
@@ -1956,6 +2035,8 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
 }
 
 export const FieldDescriptorProto = {
+  $type: "google.protobuf.FieldDescriptorProto" as const,
+
   encode(
     message: FieldDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2049,6 +2130,7 @@ export const FieldDescriptorProto = {
 
   fromJSON(object: any): FieldDescriptorProto {
     return {
+      $type: FieldDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       number: isSet(object.number) ? Number(object.number) : 0,
       label: isSet(object.label)
@@ -2119,11 +2201,19 @@ export const FieldDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(FieldDescriptorProto.$type, FieldDescriptorProto);
+
 function createBaseOneofDescriptorProto(): OneofDescriptorProto {
-  return { name: "", options: undefined };
+  return {
+    $type: "google.protobuf.OneofDescriptorProto",
+    name: "",
+    options: undefined,
+  };
 }
 
 export const OneofDescriptorProto = {
+  $type: "google.protobuf.OneofDescriptorProto" as const,
+
   encode(
     message: OneofDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2163,6 +2253,7 @@ export const OneofDescriptorProto = {
 
   fromJSON(object: any): OneofDescriptorProto {
     return {
+      $type: OneofDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       options: isSet(object.options)
         ? OneofOptions.fromJSON(object.options)
@@ -2193,8 +2284,11 @@ export const OneofDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(OneofDescriptorProto.$type, OneofDescriptorProto);
+
 function createBaseEnumDescriptorProto(): EnumDescriptorProto {
   return {
+    $type: "google.protobuf.EnumDescriptorProto",
     name: "",
     value: [],
     options: undefined,
@@ -2204,6 +2298,8 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
 }
 
 export const EnumDescriptorProto = {
+  $type: "google.protobuf.EnumDescriptorProto" as const,
+
   encode(
     message: EnumDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2268,6 +2364,7 @@ export const EnumDescriptorProto = {
 
   fromJSON(object: any): EnumDescriptorProto {
     return {
+      $type: EnumDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       value: Array.isArray(object?.value)
         ? object.value.map((e: any) => EnumValueDescriptorProto.fromJSON(e))
@@ -2335,11 +2432,19 @@ export const EnumDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(EnumDescriptorProto.$type, EnumDescriptorProto);
+
 function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_EnumReservedRange {
-  return { start: 0, end: 0 };
+  return {
+    $type: "google.protobuf.EnumDescriptorProto.EnumReservedRange",
+    start: 0,
+    end: 0,
+  };
 }
 
 export const EnumDescriptorProto_EnumReservedRange = {
+  $type: "google.protobuf.EnumDescriptorProto.EnumReservedRange" as const,
+
   encode(
     message: EnumDescriptorProto_EnumReservedRange,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2379,6 +2484,7 @@ export const EnumDescriptorProto_EnumReservedRange = {
 
   fromJSON(object: any): EnumDescriptorProto_EnumReservedRange {
     return {
+      $type: EnumDescriptorProto_EnumReservedRange.$type,
       start: isSet(object.start) ? Number(object.start) : 0,
       end: isSet(object.end) ? Number(object.end) : 0,
     };
@@ -2401,11 +2507,23 @@ export const EnumDescriptorProto_EnumReservedRange = {
   },
 };
 
+messageTypeRegistry.set(
+  EnumDescriptorProto_EnumReservedRange.$type,
+  EnumDescriptorProto_EnumReservedRange
+);
+
 function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
-  return { name: "", number: 0, options: undefined };
+  return {
+    $type: "google.protobuf.EnumValueDescriptorProto",
+    name: "",
+    number: 0,
+    options: undefined,
+  };
 }
 
 export const EnumValueDescriptorProto = {
+  $type: "google.protobuf.EnumValueDescriptorProto" as const,
+
   encode(
     message: EnumValueDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2454,6 +2572,7 @@ export const EnumValueDescriptorProto = {
 
   fromJSON(object: any): EnumValueDescriptorProto {
     return {
+      $type: EnumValueDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       number: isSet(object.number) ? Number(object.number) : 0,
       options: isSet(object.options)
@@ -2487,11 +2606,23 @@ export const EnumValueDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(
+  EnumValueDescriptorProto.$type,
+  EnumValueDescriptorProto
+);
+
 function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
-  return { name: "", method: [], options: undefined };
+  return {
+    $type: "google.protobuf.ServiceDescriptorProto",
+    name: "",
+    method: [],
+    options: undefined,
+  };
 }
 
 export const ServiceDescriptorProto = {
+  $type: "google.protobuf.ServiceDescriptorProto" as const,
+
   encode(
     message: ServiceDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2539,6 +2670,7 @@ export const ServiceDescriptorProto = {
 
   fromJSON(object: any): ServiceDescriptorProto {
     return {
+      $type: ServiceDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       method: Array.isArray(object?.method)
         ? object.method.map((e: any) => MethodDescriptorProto.fromJSON(e))
@@ -2581,8 +2713,11 @@ export const ServiceDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(ServiceDescriptorProto.$type, ServiceDescriptorProto);
+
 function createBaseMethodDescriptorProto(): MethodDescriptorProto {
   return {
+    $type: "google.protobuf.MethodDescriptorProto",
     name: "",
     inputType: "",
     outputType: "",
@@ -2593,6 +2728,8 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
 }
 
 export const MethodDescriptorProto = {
+  $type: "google.protobuf.MethodDescriptorProto" as const,
+
   encode(
     message: MethodDescriptorProto,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2656,6 +2793,7 @@ export const MethodDescriptorProto = {
 
   fromJSON(object: any): MethodDescriptorProto {
     return {
+      $type: MethodDescriptorProto.$type,
       name: isSet(object.name) ? String(object.name) : "",
       inputType: isSet(object.inputType) ? String(object.inputType) : "",
       outputType: isSet(object.outputType) ? String(object.outputType) : "",
@@ -2704,8 +2842,11 @@ export const MethodDescriptorProto = {
   },
 };
 
+messageTypeRegistry.set(MethodDescriptorProto.$type, MethodDescriptorProto);
+
 function createBaseFileOptions(): FileOptions {
   return {
+    $type: "google.protobuf.FileOptions",
     javaPackage: "",
     javaOuterClassname: "",
     javaMultipleFiles: false,
@@ -2731,6 +2872,8 @@ function createBaseFileOptions(): FileOptions {
 }
 
 export const FileOptions = {
+  $type: "google.protobuf.FileOptions" as const,
+
   encode(
     message: FileOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -2883,6 +3026,7 @@ export const FileOptions = {
 
   fromJSON(object: any): FileOptions {
     return {
+      $type: FileOptions.$type,
       javaPackage: isSet(object.javaPackage) ? String(object.javaPackage) : "",
       javaOuterClassname: isSet(object.javaOuterClassname)
         ? String(object.javaOuterClassname)
@@ -3024,8 +3168,11 @@ export const FileOptions = {
   },
 };
 
+messageTypeRegistry.set(FileOptions.$type, FileOptions);
+
 function createBaseMessageOptions(): MessageOptions {
   return {
+    $type: "google.protobuf.MessageOptions",
     messageSetWireFormat: false,
     noStandardDescriptorAccessor: false,
     deprecated: false,
@@ -3035,6 +3182,8 @@ function createBaseMessageOptions(): MessageOptions {
 }
 
 export const MessageOptions = {
+  $type: "google.protobuf.MessageOptions" as const,
+
   encode(
     message: MessageOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3091,6 +3240,7 @@ export const MessageOptions = {
 
   fromJSON(object: any): MessageOptions {
     return {
+      $type: MessageOptions.$type,
       messageSetWireFormat: isSet(object.messageSetWireFormat)
         ? Boolean(object.messageSetWireFormat)
         : false,
@@ -3142,8 +3292,11 @@ export const MessageOptions = {
   },
 };
 
+messageTypeRegistry.set(MessageOptions.$type, MessageOptions);
+
 function createBaseFieldOptions(): FieldOptions {
   return {
+    $type: "google.protobuf.FieldOptions",
     ctype: 0,
     packed: false,
     jstype: 0,
@@ -3155,6 +3308,8 @@ function createBaseFieldOptions(): FieldOptions {
 }
 
 export const FieldOptions = {
+  $type: "google.protobuf.FieldOptions" as const,
+
   encode(
     message: FieldOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3223,6 +3378,7 @@ export const FieldOptions = {
 
   fromJSON(object: any): FieldOptions {
     return {
+      $type: FieldOptions.$type,
       ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
       packed: isSet(object.packed) ? Boolean(object.packed) : false,
       jstype: isSet(object.jstype)
@@ -3277,11 +3433,15 @@ export const FieldOptions = {
   },
 };
 
+messageTypeRegistry.set(FieldOptions.$type, FieldOptions);
+
 function createBaseOneofOptions(): OneofOptions {
-  return { uninterpretedOption: [] };
+  return { $type: "google.protobuf.OneofOptions", uninterpretedOption: [] };
 }
 
 export const OneofOptions = {
+  $type: "google.protobuf.OneofOptions" as const,
+
   encode(
     message: OneofOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3314,6 +3474,7 @@ export const OneofOptions = {
 
   fromJSON(object: any): OneofOptions {
     return {
+      $type: OneofOptions.$type,
       uninterpretedOption: Array.isArray(object?.uninterpretedOption)
         ? object.uninterpretedOption.map((e: any) =>
             UninterpretedOption.fromJSON(e)
@@ -3346,11 +3507,20 @@ export const OneofOptions = {
   },
 };
 
+messageTypeRegistry.set(OneofOptions.$type, OneofOptions);
+
 function createBaseEnumOptions(): EnumOptions {
-  return { allowAlias: false, deprecated: false, uninterpretedOption: [] };
+  return {
+    $type: "google.protobuf.EnumOptions",
+    allowAlias: false,
+    deprecated: false,
+    uninterpretedOption: [],
+  };
 }
 
 export const EnumOptions = {
+  $type: "google.protobuf.EnumOptions" as const,
+
   encode(
     message: EnumOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3395,6 +3565,7 @@ export const EnumOptions = {
 
   fromJSON(object: any): EnumOptions {
     return {
+      $type: EnumOptions.$type,
       allowAlias: isSet(object.allowAlias) ? Boolean(object.allowAlias) : false,
       deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
       uninterpretedOption: Array.isArray(object?.uninterpretedOption)
@@ -3433,11 +3604,19 @@ export const EnumOptions = {
   },
 };
 
+messageTypeRegistry.set(EnumOptions.$type, EnumOptions);
+
 function createBaseEnumValueOptions(): EnumValueOptions {
-  return { deprecated: false, uninterpretedOption: [] };
+  return {
+    $type: "google.protobuf.EnumValueOptions",
+    deprecated: false,
+    uninterpretedOption: [],
+  };
 }
 
 export const EnumValueOptions = {
+  $type: "google.protobuf.EnumValueOptions" as const,
+
   encode(
     message: EnumValueOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3476,6 +3655,7 @@ export const EnumValueOptions = {
 
   fromJSON(object: any): EnumValueOptions {
     return {
+      $type: EnumValueOptions.$type,
       deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
       uninterpretedOption: Array.isArray(object?.uninterpretedOption)
         ? object.uninterpretedOption.map((e: any) =>
@@ -3511,11 +3691,19 @@ export const EnumValueOptions = {
   },
 };
 
+messageTypeRegistry.set(EnumValueOptions.$type, EnumValueOptions);
+
 function createBaseServiceOptions(): ServiceOptions {
-  return { deprecated: false, uninterpretedOption: [] };
+  return {
+    $type: "google.protobuf.ServiceOptions",
+    deprecated: false,
+    uninterpretedOption: [],
+  };
 }
 
 export const ServiceOptions = {
+  $type: "google.protobuf.ServiceOptions" as const,
+
   encode(
     message: ServiceOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3554,6 +3742,7 @@ export const ServiceOptions = {
 
   fromJSON(object: any): ServiceOptions {
     return {
+      $type: ServiceOptions.$type,
       deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
       uninterpretedOption: Array.isArray(object?.uninterpretedOption)
         ? object.uninterpretedOption.map((e: any) =>
@@ -3589,11 +3778,20 @@ export const ServiceOptions = {
   },
 };
 
+messageTypeRegistry.set(ServiceOptions.$type, ServiceOptions);
+
 function createBaseMethodOptions(): MethodOptions {
-  return { deprecated: false, idempotencyLevel: 0, uninterpretedOption: [] };
+  return {
+    $type: "google.protobuf.MethodOptions",
+    deprecated: false,
+    idempotencyLevel: 0,
+    uninterpretedOption: [],
+  };
 }
 
 export const MethodOptions = {
+  $type: "google.protobuf.MethodOptions" as const,
+
   encode(
     message: MethodOptions,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3638,6 +3836,7 @@ export const MethodOptions = {
 
   fromJSON(object: any): MethodOptions {
     return {
+      $type: MethodOptions.$type,
       deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
       idempotencyLevel: isSet(object.idempotencyLevel)
         ? methodOptions_IdempotencyLevelFromJSON(object.idempotencyLevel)
@@ -3681,8 +3880,11 @@ export const MethodOptions = {
   },
 };
 
+messageTypeRegistry.set(MethodOptions.$type, MethodOptions);
+
 function createBaseUninterpretedOption(): UninterpretedOption {
   return {
+    $type: "google.protobuf.UninterpretedOption",
     name: [],
     identifierValue: "",
     positiveIntValue: Long.UZERO,
@@ -3694,6 +3896,8 @@ function createBaseUninterpretedOption(): UninterpretedOption {
 }
 
 export const UninterpretedOption = {
+  $type: "google.protobuf.UninterpretedOption" as const,
+
   encode(
     message: UninterpretedOption,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3765,6 +3969,7 @@ export const UninterpretedOption = {
 
   fromJSON(object: any): UninterpretedOption {
     return {
+      $type: UninterpretedOption.$type,
       name: Array.isArray(object?.name)
         ? object.name.map((e: any) => UninterpretedOption_NamePart.fromJSON(e))
         : [],
@@ -3842,11 +4047,19 @@ export const UninterpretedOption = {
   },
 };
 
+messageTypeRegistry.set(UninterpretedOption.$type, UninterpretedOption);
+
 function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart {
-  return { namePart: "", isExtension: false };
+  return {
+    $type: "google.protobuf.UninterpretedOption.NamePart",
+    namePart: "",
+    isExtension: false,
+  };
 }
 
 export const UninterpretedOption_NamePart = {
+  $type: "google.protobuf.UninterpretedOption.NamePart" as const,
+
   encode(
     message: UninterpretedOption_NamePart,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3886,6 +4099,7 @@ export const UninterpretedOption_NamePart = {
 
   fromJSON(object: any): UninterpretedOption_NamePart {
     return {
+      $type: UninterpretedOption_NamePart.$type,
       namePart: isSet(object.namePart) ? String(object.namePart) : "",
       isExtension: isSet(object.isExtension)
         ? Boolean(object.isExtension)
@@ -3911,11 +4125,18 @@ export const UninterpretedOption_NamePart = {
   },
 };
 
+messageTypeRegistry.set(
+  UninterpretedOption_NamePart.$type,
+  UninterpretedOption_NamePart
+);
+
 function createBaseSourceCodeInfo(): SourceCodeInfo {
-  return { location: [] };
+  return { $type: "google.protobuf.SourceCodeInfo", location: [] };
 }
 
 export const SourceCodeInfo = {
+  $type: "google.protobuf.SourceCodeInfo" as const,
+
   encode(
     message: SourceCodeInfo,
     writer: _m0.Writer = _m0.Writer.create()
@@ -3948,6 +4169,7 @@ export const SourceCodeInfo = {
 
   fromJSON(object: any): SourceCodeInfo {
     return {
+      $type: SourceCodeInfo.$type,
       location: Array.isArray(object?.location)
         ? object.location.map((e: any) => SourceCodeInfo_Location.fromJSON(e))
         : [],
@@ -3976,8 +4198,11 @@ export const SourceCodeInfo = {
   },
 };
 
+messageTypeRegistry.set(SourceCodeInfo.$type, SourceCodeInfo);
+
 function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
   return {
+    $type: "google.protobuf.SourceCodeInfo.Location",
     path: [],
     span: [],
     leadingComments: "",
@@ -3987,6 +4212,8 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
 }
 
 export const SourceCodeInfo_Location = {
+  $type: "google.protobuf.SourceCodeInfo.Location" as const,
+
   encode(
     message: SourceCodeInfo_Location,
     writer: _m0.Writer = _m0.Writer.create()
@@ -4062,6 +4289,7 @@ export const SourceCodeInfo_Location = {
 
   fromJSON(object: any): SourceCodeInfo_Location {
     return {
+      $type: SourceCodeInfo_Location.$type,
       path: Array.isArray(object?.path)
         ? object.path.map((e: any) => Number(e))
         : [],
@@ -4120,11 +4348,15 @@ export const SourceCodeInfo_Location = {
   },
 };
 
+messageTypeRegistry.set(SourceCodeInfo_Location.$type, SourceCodeInfo_Location);
+
 function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
-  return { annotation: [] };
+  return { $type: "google.protobuf.GeneratedCodeInfo", annotation: [] };
 }
 
 export const GeneratedCodeInfo = {
+  $type: "google.protobuf.GeneratedCodeInfo" as const,
+
   encode(
     message: GeneratedCodeInfo,
     writer: _m0.Writer = _m0.Writer.create()
@@ -4160,6 +4392,7 @@ export const GeneratedCodeInfo = {
 
   fromJSON(object: any): GeneratedCodeInfo {
     return {
+      $type: GeneratedCodeInfo.$type,
       annotation: Array.isArray(object?.annotation)
         ? object.annotation.map((e: any) =>
             GeneratedCodeInfo_Annotation.fromJSON(e)
@@ -4192,11 +4425,21 @@ export const GeneratedCodeInfo = {
   },
 };
 
+messageTypeRegistry.set(GeneratedCodeInfo.$type, GeneratedCodeInfo);
+
 function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation {
-  return { path: [], sourceFile: "", begin: 0, end: 0 };
+  return {
+    $type: "google.protobuf.GeneratedCodeInfo.Annotation",
+    path: [],
+    sourceFile: "",
+    begin: 0,
+    end: 0,
+  };
 }
 
 export const GeneratedCodeInfo_Annotation = {
+  $type: "google.protobuf.GeneratedCodeInfo.Annotation" as const,
+
   encode(
     message: GeneratedCodeInfo_Annotation,
     writer: _m0.Writer = _m0.Writer.create()
@@ -4257,6 +4500,7 @@ export const GeneratedCodeInfo_Annotation = {
 
   fromJSON(object: any): GeneratedCodeInfo_Annotation {
     return {
+      $type: GeneratedCodeInfo_Annotation.$type,
       path: Array.isArray(object?.path)
         ? object.path.map((e: any) => Number(e))
         : [],
@@ -4290,6 +4534,11 @@ export const GeneratedCodeInfo_Annotation = {
     return message;
   },
 };
+
+messageTypeRegistry.set(
+  GeneratedCodeInfo_Annotation.$type,
+  GeneratedCodeInfo_Annotation
+);
 
 declare var self: any | undefined;
 declare var window: any | undefined;
@@ -4343,14 +4592,14 @@ export type DeepPartial<T> = T extends Builtin
   : T extends ReadonlyArray<infer U>
   ? ReadonlyArray<DeepPartial<U>>
   : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
+        Exclude<keyof I, KeysOfUnion<P> | "$type">,
         never
       >;
 

--- a/src/protobuf/typeRegistry.ts
+++ b/src/protobuf/typeRegistry.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+import _m0 from "protobufjs/minimal";
+import Long from "long";
+
+export interface MessageType<Message extends UnknownMessage = UnknownMessage> {
+  $type: Message["$type"];
+  encode(message: Message, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): Message;
+  fromJSON(object: any): Message;
+  toJSON(message: Message): unknown;
+  fromPartial(object: DeepPartial<Message>): Message;
+}
+
+export type UnknownMessage = { $type: string };
+
+export const messageTypeRegistry = new Map<string, MessageType>();
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in Exclude<keyof T, "$type">]?: DeepPartial<T[K]> }
+  : Partial<T>;

--- a/src/stargate/index.ts
+++ b/src/stargate/index.ts
@@ -1,11 +1,10 @@
-import { MsgCreateCertificate, MsgRevokeCertificate } from "../protobuf/akash/cert/v1beta1/cert";
+import { MessageType, messageTypeRegistry, UnknownMessage } from "../protobuf/typeRegistry";
 
-// duplication here for now, could make this cleaner through run time enumeration
-// one for stargate, one to make life easier for devs
-export const registry = [
-  ["/akash.cert.v1beta1.MsgCreateCertificate", MsgCreateCertificate],
-  ["/akash.cert.v1beta1.MsgRevokeCertificate", MsgRevokeCertificate],
-];
+export const getAkashTypeRegistry: () => ([string, MessageType<UnknownMessage>][])
+  = () => Array.from(messageTypeRegistry).map(([path, type]) => [`/${path}`, type])
+
+export const getTypeUrl: (type: MessageType) => string
+  = (type) => `/${type.$type}`
 
 export enum messages {
   MsgCreateCertificate = "/akash.cert.v1beta1.MsgCreateCertificate",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,9 @@
+export const prop = (key: string) => (context: any) => context[key];
+
+export const sortBy = (evalFn: (arg0: any) => any) => (xs: any[]) => xs.sort((a, b) => evalFn(a) - evalFn(b));
+
+export const map = (fn: any) => (xs: any[]) => xs.map(fn);
+
+export const filter = (fn: any) => (xs: any[]) => xs.filter(fn);
+
+export const awaitAll = Promise.all.bind(Promise);


### PR DESCRIPTION
Uses ts-proto to create a type registry for generated types, and adds some utility methods to make it play nicely with cosmjs.