### PR TITLE
Fix wrong encoding

### DIFF
--- a/src/protobuf/akash/base/v1beta2/attribute.ts
+++ b/src/protobuf/akash/base/v1beta2/attribute.ts
@@ -80,7 +80,7 @@ export const Attribute = {
     return {
       $type: Attribute.$type,
       key: isSet(object.key) ? String(object.key) : "",
-      value: isSet(object.val) ? bytesFromBase64(object.val) : new Uint8Array(),
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
     };
   },
 
@@ -89,7 +89,7 @@ export const Attribute = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     message.value !== undefined &&
-    (obj.val = base64FromBytes(
+    (obj.value = base64FromBytes(
         message.value !== undefined ? message.value : new Uint8Array()
     ));
     return obj;

--- a/src/protobuf/akash/base/v1beta2/attribute.ts
+++ b/src/protobuf/akash/base/v1beta2/attribute.ts
@@ -87,7 +87,6 @@ export const Attribute = {
   toJSON(message: Attribute): unknown {
     const obj: any = {};
     message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
     message.value !== undefined &&
     (obj.value = base64FromBytes(
         message.value !== undefined ? message.value : new Uint8Array()


### PR DESCRIPTION
This is a fix for the wrong encoding of the attributes array for persistent storage.
The issue was that `akasj.js` was expecting a string instead `Uint8Array`.